### PR TITLE
Detect nested writers that would deadlock

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -17,6 +17,7 @@
 
 ### New features
 
+- [Database] `new Database({ experimentalDetectNestedWriters: true })` throws immediately when a reader/writer is called from another without `callWriter()`/`callReader()`, instead of deadlocking. Detection covers the same JS turn and the continuation after Watermelon adapter awaits (`find` / `query` / `batch`).
 - [Electron] Added `RemoteAdapter` so SQLite can run in Electron's main process over IPC (or any serializable transport). Cherry-picked from [Nozbe/WatermelonDB#1859](https://github.com/Nozbe/WatermelonDB/pull/1859) by [@feznyng](https://github.com/feznyng)
 - [Expo] First-class Expo support: config plugin (`app.plugin.js`) for development builds, EAS Build, and EAS Update. Add `"nitromelondb"` to `app.json` `plugins`. Replaces `@morrowdigital/watermelondb-expo-plugin` (Android JSI wiring is not used; SQLite is Nitro). Optional `{ "excludeSimArch": true }`.
 

--- a/docs-website/docs/docs/Advanced/DetectNestedWriters.md
+++ b/docs-website/docs/docs/Advanced/DetectNestedWriters.md
@@ -1,0 +1,118 @@
+---
+title: Detect nested writers (deadlock prevention)
+hide_title: true
+---
+
+# Detect nested writers (deadlock prevention)
+
+If you call a Writer from another Writer (or a Reader from a Reader/Writer) **without** `callWriter()` / `callReader()`, the inner work is queued behind the outer one. If you `await` that nested call, **neither ever finishes**.
+
+`experimentalDetectNestedWriters` makes that fail fast instead of hanging.
+
+This is **opt-in** and **off by default**. With the flag unset, nested writers still deadlock as they always have.
+
+## Enable
+
+Pass the flag when you create the database:
+
+```js
+const database = new Database({
+  adapter,
+  modelClasses: [
+    // ...
+  ],
+  experimentalDetectNestedWriters: true,
+})
+```
+
+When it is on, a nested `database.write()` / `database.read()` (or `@writer` / `@reader`) without `callWriter()` / `callReader()` **throws immediately**.
+
+## What is detected
+
+Detection covers two windows:
+
+1. Nested calls on the **same JavaScript turn** — still running synchronously in the outer writer, before its first `await`.
+2. Nested calls **after a Watermelon await** — `find`, `query` / `fetch` / `fetchCount` / `fetchIds` / `unsafeFetchRaw`, `create`, `update`, `batch`.
+
+These throw:
+
+```js
+// Nested on the same JS turn
+database.write(async () => {
+  await nested() // nested is database.write(...) without callWriter
+})
+
+database.write(async () => {
+  nested() // not even awaited — also throws (see caveats)
+})
+
+// Nested after a Watermelon await (including a cached find)
+database.write(async () => {
+  await tasks.find(task.id)
+  await nested()
+})
+```
+
+The error looks like:
+
+```
+Nested writer (nested writer) called from writer (outer writer) without callWriter()/callReader(). This deadlocks.
+```
+
+## What still works
+
+**`callWriter` / `callReader` are exempt.** Legitimate nested work keeps running as part of the outer block, including after `await find()`:
+
+```js
+await database.write(async writer => {
+  await tasks.find(task.id)
+  return writer.callWriter(() => nested())
+})
+```
+
+**Independent writers still queue.** A second `database.write()` started from the UI while another writer is awaiting (for example while sync is running) is **not** nested. It waits its turn as usual:
+
+```js
+const first = database.write(async () => {
+  await tasks.find(task.id)
+  await delay() // still the first writer; nothing nested
+})
+const second = database.write(async () => 'queued') // from the UI / another event
+await first
+await second // 'queued'
+```
+
+JavaScript is single-threaded. Those independent calls run as a later macrotask, not inside the outer writer's synchronous continuation, so they are not treated as nested.
+
+## Caveats (flag on)
+
+### Detection is best-effort
+
+A nested write **after a non-Watermelon await** is not detected. That continuation is no longer known to be "inside" the writer:
+
+```js
+database.write(async () => {
+  await fetch(url) // network / timer / anything that is not a Watermelon API
+  await nested()   // still deadlocks; this flag will not throw
+})
+```
+
+Only Watermelon adapter awaits (`find` / `query` / `batch` and the methods listed above) re-arm detection for the next turn.
+
+### Fire-and-forget nested writes also throw
+
+This does **not** technically deadlock — the un-awaited inner write would queue after the outer one finishes — but with the flag on it still throws:
+
+```js
+database.write(async () => {
+  database.write(async () => {
+    // ...
+  })
+})
+```
+
+Treat that as a forgotten nest. If the inner work belongs in this writer, use `callWriter`. If it should run later on its own, start it from outside the writer (for example from the UI).
+
+## See also
+
+- [Writers: nesting writers or readers](../Writers.md#advanced-nesting-writers-or-readers)

--- a/docs-website/docs/docs/Setup.md
+++ b/docs-website/docs/docs/Setup.md
@@ -69,6 +69,8 @@ const database = new Database({
   modelClasses: [
     // Post, // ⬅️ You'll add Models to Watermelon here
   ],
+  // Throws if you call a writer from another writer without callWriter() (instead of deadlocking)
+  // experimentalDetectNestedWriters: true,
 })
 ```
 

--- a/docs-website/docs/docs/Writers.md
+++ b/docs-website/docs/docs/Writers.md
@@ -241,6 +241,22 @@ database.write(async writer => {
 
 The same is true with Readers - use `callReader` to nest readers.
 
+If you forget `callWriter` / `callReader` and `await` the nested call, the inner work is queued behind the outer one and **neither ever finishes**.
+
+To fail fast instead of hanging, pass `experimentalDetectNestedWriters: true` when creating the database:
+
+```js
+const database = new Database({
+  adapter,
+  modelClasses: [
+    // ...
+  ],
+  experimentalDetectNestedWriters: true,
+})
+```
+
+This throws as soon as a nested `database.write()` / `database.read()` (or `@writer` / `@reader`) runs without `callWriter()` / `callReader()`. That includes nested calls on the same JS turn and after a Watermelon await (`find`, `query`, `batch`). Independent writers queued from the UI (for example while sync is running) still wait as usual.
+
 * * *
 
 ## Next steps

--- a/docs-website/docs/docs/Writers.md
+++ b/docs-website/docs/docs/Writers.md
@@ -257,6 +257,8 @@ const database = new Database({
 
 This throws as soon as a nested `database.write()` / `database.read()` (or `@writer` / `@reader`) runs without `callWriter()` / `callReader()`. That includes nested calls on the same JS turn and after a Watermelon await (`find`, `query`, `batch`). Independent writers queued from the UI (for example while sync is running) still wait as usual.
 
+Detection is best-effort (a nested write after a non-Watermelon `await`, like `fetch()`, is not caught). Fire-and-forget nested `write()` also throws. Details, examples, and caveats: **[Detect nested writers (deadlock prevention)](./Advanced/DetectNestedWriters.md)**.
+
 * * *
 
 ## Next steps

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -45,6 +45,7 @@ const sidebars = {
       'docs/Advanced/Flow',
       'docs/Advanced/LocalStorage',
       'docs/Advanced/ProTips',
+      'docs/Advanced/DetectNestedWriters',
       'docs/Advanced/Performance',
       'docs/Advanced/SharingDatabaseAcrossTargets',
     ],

--- a/src/Collection/index.ts
+++ b/src/Collection/index.ts
@@ -88,8 +88,10 @@ export default class Collection<Record extends Model> {
    *
    * If the record is not found, the Promise will reject.
    */
-  async find(id: RecordId): Promise<Record> {
-    return toPromise((callback) => this._fetchRecord(id, callback))
+  find(id: RecordId): Promise<Record> {
+    return this.database._workQueue.followPromise(
+      toPromise((callback) => this._fetchRecord(id, callback)),
+    )
   }
 
   /**
@@ -149,7 +151,11 @@ export default class Collection<Record extends Model> {
    * })
    * ```
    */
-  async create(recordBuilder: (record: Record) => void = noop): Promise<Record> {
+  create(recordBuilder: (record: Record) => void = noop): Promise<Record> {
+    return this.database._workQueue.followPromise(this._performCreate(recordBuilder))
+  }
+
+  async _performCreate(recordBuilder: (record: Record) => void): Promise<Record> {
     this.database._ensureInWriter(`Collection.create()`)
 
     const record = this.prepareCreate(recordBuilder)

--- a/src/Database/WorkQueue.ts
+++ b/src/Database/WorkQueue.ts
@@ -110,8 +110,49 @@ export default class WorkQueue {
 
   _subActionIncoming: boolean = false
 
+  _inWorkTurn: boolean = false
+
   constructor(db: Database) {
     this._db = db
+  }
+
+  /**
+   * When a writer `await`s this promise, mark the next microtask as still inside that writer
+   * so a nested write() without callWriter throws.
+   */
+  followPromise<T>(promise: Promise<T>): Promise<T> {
+    if (!this._db.experimentalDetectNestedWriters || !this._inWorkTurn) {
+      return promise
+    }
+
+    const workItem = this._queue[0]
+    return new Promise((resolve, reject) => {
+      const resume = (): void => {
+        if (this._queue[0] === workItem) {
+          this._inWorkTurn = true
+        }
+      }
+      const endResume = (): void => {
+        queueMicrotask(() => {
+          if (this._queue[0] === workItem) {
+            this._inWorkTurn = false
+          }
+        })
+      }
+
+      promise.then(
+        (value) => {
+          resume()
+          resolve(value)
+          endResume()
+        },
+        (error) => {
+          resume()
+          reject(error)
+          endResume()
+        },
+      )
+    })
   }
 
   get isWriterRunning(): boolean {
@@ -142,6 +183,19 @@ export default class WorkQueue {
         invariant(!isWriter, 'Cannot call a writer block from a reader block')
       }
       return work(actionInterface(this, currentWork) as unknown as WriterInterface)
+    }
+
+    if (this._db.experimentalDetectNestedWriters && this._inWorkTurn) {
+      const currentWork = this._queue[0]
+      if (currentWork) {
+        const nestedKind = isWriter ? 'writer' : 'reader'
+        const currentKind = currentWork.isWriter ? 'writer' : 'reader'
+        throw new Error(
+          `Nested ${nestedKind} (${description || 'unnamed'}) called from ${currentKind} (${
+            currentWork.description || 'unnamed'
+          }) without callWriter()/callReader(). This deadlocks.`,
+        )
+      }
     }
 
     return new Promise((resolve, reject) => {
@@ -205,7 +259,13 @@ export default class WorkQueue {
     const { work, resolve, reject, isWriter } = workItem
 
     try {
-      const workPromise = work(actionInterface(this, workItem))
+      this._inWorkTurn = this._db.experimentalDetectNestedWriters
+      let workPromise: Promise<unknown>
+      try {
+        workPromise = work(actionInterface(this, workItem))
+      } finally {
+        this._inWorkTurn = false
+      }
 
       if (process.env.NODE_ENV !== 'production') {
         invariant(

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -15,9 +15,18 @@ import CollectionMap from './CollectionMap'
 import type LocalStorage from './LocalStorage'
 import WorkQueue, { type ReaderInterface, type WriterInterface } from './WorkQueue'
 
-type DatabaseProps = {
+export type DatabaseProps = {
   adapter: DatabaseAdapter
   modelClasses: ModelClass<Model>[]
+  /**
+   * If true, calling `database.write()` / `database.read()` (or `@writer` / `@reader`) from inside
+   * an already running reader/writer, without `callWriter()` / `callReader()`, throws immediately
+   * instead of deadlocking.
+   *
+   * Detection covers nested calls on the same JS turn and after Watermelon adapter awaits
+   * (`find` / `query` / `batch`). Independent writers queued from the UI still wait as usual.
+   */
+  experimentalDetectNestedWriters?: boolean | undefined
 }
 
 type TableChange = [TableName, CollectionChangeSet<Model>]
@@ -44,13 +53,19 @@ export default class Database {
 
   _workQueue: WorkQueue = new WorkQueue(this)
 
+  /**
+   * When true, nested readers/writers without callReader/callWriter throw instead of deadlocking.
+   * @see {DatabaseProps#experimentalDetectNestedWriters}
+   */
+  experimentalDetectNestedWriters: boolean = false
+
   // (experimental) if true, Database is in a broken state and should not be used anymore
   _isBroken: boolean = false
 
   _localStorage: LocalStorage | undefined
 
   constructor(options: DatabaseProps) {
-    const { adapter, modelClasses } = options
+    const { adapter, modelClasses, experimentalDetectNestedWriters = false } = options
     if (process.env.NODE_ENV !== 'production') {
       invariant(adapter, `Missing adapter parameter for new Database()`)
       invariant(
@@ -58,6 +73,7 @@ export default class Database {
         `Missing modelClasses parameter for new Database()`,
       )
     }
+    this.experimentalDetectNestedWriters = experimentalDetectNestedWriters
     this.adapter = new DatabaseAdapterCompat(adapter)
     this.schema = adapter.schema
     this.collections = new CollectionMap(this, modelClasses)
@@ -98,7 +114,11 @@ export default class Database {
    */
   batch(...records: Array<Model | null | undefined | false>): Promise<void>
   batch(records: Array<Model | null | undefined | false>): Promise<void>
-  async batch(...args: unknown[]): Promise<void> {
+  batch(...args: unknown[]): Promise<void> {
+    return this._workQueue.followPromise(this._performBatch(args))
+  }
+
+  async _performBatch(args: unknown[]): Promise<void> {
     const actualRecords = fromArrayOrSpread<Model | null | undefined | false>(
       args,
       'Database.batch',
@@ -243,7 +263,8 @@ export default class Database {
    * the duration of this Writer (except if changed by it).
    *
    * To call another Writer (or Reader) from this one without deadlocking, use `callWriter`
-   * (or `callReader`).
+   * (or `callReader`). If {@link DatabaseProps#experimentalDetectNestedWriters} is enabled, a nested write
+   * without `callWriter` throws instead of hanging forever.
    *
    * See docs for more details and a practical guide.
    *

--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -641,6 +641,97 @@ describe('Database', () => {
       })
       expect(called).toBe(0)
     })
+    it('experimentalDetectNestedWriters throws instead of deadlocking on nested writers', async () => {
+      const { database } = mockDatabase({ experimentalDetectNestedWriters: true })
+
+      const nested = () => database.write(async () => 1, 'nested writer')
+
+      await expectToRejectWithMessage(
+        database.write(async () => nested(), 'outer writer'),
+        'This deadlocks',
+      )
+
+      await expectToRejectWithMessage(
+        database.write(async () => {
+          nested()
+        }, 'outer writer'),
+        'This deadlocks',
+      )
+    })
+    it('experimentalDetectNestedWriters throws on nested readers without callReader', async () => {
+      const { database } = mockDatabase({ experimentalDetectNestedWriters: true })
+
+      const nested = () => database.read(async () => 1, 'nested reader')
+
+      await expectToRejectWithMessage(
+        database.write(async () => nested(), 'outer writer'),
+        'This deadlocks',
+      )
+    })
+    it('experimentalDetectNestedWriters still allows callWriter/callReader and queued writers', async () => {
+      const { database } = mockDatabase({ experimentalDetectNestedWriters: true })
+
+      const nested = () => database.write(async () => 42, 'nested writer')
+      expect(
+        await database.write(async (writer) => writer.callWriter(() => nested()), 'outer writer'),
+      ).toBe(42)
+
+      const first = database.write(delayPromise, 'first writer')
+      const second = database.write(async () => 'queued', 'second writer')
+      await first
+      expect(await second).toBe('queued')
+    })
+    it('experimentalDetectNestedWriters throws after await find without callWriter', async () => {
+      const { database, tasks } = mockDatabase({ experimentalDetectNestedWriters: true })
+      const task = await database.write(() => tasks.create())
+      const nested = () => database.write(async () => 1, 'nested writer')
+
+      await expectToRejectWithMessage(
+        database.write(async () => {
+          await tasks.find(task.id)
+          await nested()
+        }, 'outer writer'),
+        'This deadlocks',
+      )
+    })
+    it('experimentalDetectNestedWriters throws after a cached find without callWriter', async () => {
+      const { database, tasks } = mockDatabase({ experimentalDetectNestedWriters: true })
+      const task = await database.write(() => tasks.create())
+      await tasks.find(task.id)
+      const nested = () => database.write(async () => 1, 'nested writer')
+
+      await expectToRejectWithMessage(
+        database.write(async () => {
+          await tasks.find(task.id)
+          await nested()
+        }, 'outer writer'),
+        'This deadlocks',
+      )
+    })
+    it('experimentalDetectNestedWriters still queues writers started after an adapter await', async () => {
+      const { database, tasks } = mockDatabase({ experimentalDetectNestedWriters: true })
+      const task = await database.write(() => tasks.create())
+
+      const first = database.write(async () => {
+        await tasks.find(task.id)
+        await delayPromise()
+      }, 'first writer')
+      const second = database.write(async () => 'queued', 'second writer')
+      await first
+      expect(await second).toBe('queued')
+    })
+    it('experimentalDetectNestedWriters still allows callWriter after await find', async () => {
+      const { database, tasks } = mockDatabase({ experimentalDetectNestedWriters: true })
+      const task = await database.write(() => tasks.create())
+      const nested = () => database.write(async () => 42, 'nested writer')
+
+      expect(
+        await database.write(async (writer) => {
+          await tasks.find(task.id)
+          return writer.callWriter(() => nested())
+        }, 'outer writer'),
+      ).toBe(42)
+    })
     it(`can call readers with callReader`, async () => {
       const { db } = mockDatabase()
 

--- a/src/Model/index.ts
+++ b/src/Model/index.ts
@@ -105,7 +105,11 @@ export default class Model {
    *   task.name = 'New name'
    * })
    */
-  async update(recordUpdater: (record: this) => void = noop): Promise<this> {
+  update(recordUpdater: (record: this) => void = noop): Promise<this> {
+    return this.db._workQueue.followPromise(this._performUpdate(recordUpdater))
+  }
+
+  async _performUpdate(recordUpdater: (record: this) => void): Promise<this> {
     this.__ensureInWriter(`Model.update()`)
     const record = this.prepareUpdate(recordUpdater)
     await this.db.batch(this)

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -118,7 +118,9 @@ export default class Query<Record extends Model> {
    * Tip: For convenience, you can also use `await query`
    */
   fetch(): Promise<Record[]> {
-    return toPromise((callback) => this.collection._fetchQuery(this, callback))
+    return this.collection.database._workQueue.followPromise(
+      toPromise((callback) => this.collection._fetchQuery(this, callback)),
+    )
   }
 
   then<U>(
@@ -161,7 +163,9 @@ export default class Query<Record extends Model> {
    * Tip: For convenience you can also use `await query.count`
    */
   fetchCount(): Promise<number> {
-    return toPromise((callback) => this.collection._fetchCount(this, callback))
+    return this.collection.database._workQueue.followPromise(
+      toPromise((callback) => this.collection._fetchCount(this, callback)),
+    )
   }
 
   get count(): QueryCountProxy {
@@ -198,7 +202,9 @@ export default class Query<Record extends Model> {
    * Note: This is faster than using `fetch()` if you only need IDs
    */
   fetchIds(): Promise<RecordId[]> {
-    return toPromise((callback) => this.collection._fetchIds(this, callback))
+    return this.collection.database._workQueue.followPromise(
+      toPromise((callback) => this.collection._fetchIds(this, callback)),
+    )
   }
 
   /**
@@ -211,7 +217,9 @@ export default class Query<Record extends Model> {
    * (e.g. pragmas, statistics, groupped results, records with extra columns, etc...)
    */
   unsafeFetchRaw(): Promise<unknown[]> {
-    return toPromise((callback) => this.collection._unsafeFetchRaw(this, callback))
+    return this.collection.database._workQueue.followPromise(
+      toPromise((callback) => this.collection._unsafeFetchRaw(this, callback)),
+    )
   }
 
   /**

--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -109,7 +109,11 @@ export class MockComment extends Model {
 
 export const modelClasses = [MockProject, MockProjectSection, MockTask, MockComment]
 
-export const mockDatabase = ({ schema = testSchema, migrations = undefined } = {}) => {
+export const mockDatabase = ({
+  schema = testSchema,
+  migrations = undefined,
+  experimentalDetectNestedWriters = false,
+} = {}) => {
   const adapter = new LokiJSAdapter({
     dbName: 'test',
     schema,
@@ -121,6 +125,7 @@ export const mockDatabase = ({ schema = testSchema, migrations = undefined } = {
     adapter,
     schema,
     modelClasses,
+    experimentalDetectNestedWriters,
   })
   return {
     database,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as Q from './QueryDescription'
 
 export { default as Collection } from './Collection'
 export { default as Database } from './Database'
+export type { DatabaseProps } from './Database'
 export { default as Relation } from './Relation'
 export { default as Model, associations } from './Model'
 export { default as Query } from './Query'


### PR DESCRIPTION
## Summary
- Adds opt-in `experimentalDetectNestedWriters` so nested `write()` / `read()` (or `@writer` / `@reader`) without `callWriter()` / `callReader()` throws instead of hanging forever.
- Detection covers the same JS turn and the continuation after Watermelon awaits (`find`, `query`, `batch`). Independent writers from the UI still queue as usual.
- Off by default: no behavior change unless the Database flag is set.

## Test plan
- [ ] `yarn test src/Database/test.js src/Collection/test.js src/Model/test.js src/Query/test.js src/decorators/action/test.js`
- [ ] Nested `database.write()` inside a writer without `callWriter` throws when the flag is on
- [ ] Nested write after `await collection.find()` / cached find still throws
- [ ] `callWriter` / `callReader` still work, including after `await find()`
- [ ] A second `database.write()` started from the UI while another writer is awaiting still queues (does not throw)
- [ ] Flag off: nested writers still deadlock as before (existing test)


Made with [Cursor](https://cursor.com)