### PR TITLE
Release v0.30.0-alpha.0 + Continuous Delivery Pipeline

### DIFF
--- a/.github/workflows/.secrets.example
+++ b/.github/workflows/.secrets.example
@@ -1,0 +1,9 @@
+# Example secrets file for local testing with act
+# Copy this to .secrets and fill in your values
+# NEVER commit .secrets file!
+#
+# npm publish in CI uses OIDC trusted publishing, not NPM_TOKEN.
+# `act` cannot issue GitHub OIDC tokens, so local publish simulation
+# still needs a classic token if you insist on testing publish locally.
+
+GITHUB_TOKEN=your_github_pat_here

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,162 @@
+# Release Workflows
+
+Automated releases for `nitromelondb`, modeled on the two-step process used in [react-native-google-fit](https://github.com/StasDoskalenko/react-native-google-fit).
+
+## Workflows
+
+### 1. `prepare-release.yml` — Prepare Release
+
+**Trigger:** Manual (`workflow_dispatch`)
+
+**Inputs:**
+
+| Field | Options | Purpose |
+| --- | --- | --- |
+| Version bump | `patch`, `minor`, `major` | Semver bump from the current `package.json` version |
+| Prerelease | `none`, `alpha`, `beta` | Optional prerelease channel |
+
+**What it does:**
+
+1. Calculates the next version (see [Versioning](#versioning))
+2. Creates a `release/vX.Y.Z` branch (or `release/vX.Y.Z-alpha.N` / `-beta.N`)
+3. Bumps `package.json`
+4. Moves `CHANGELOG-Unreleased.md` into `CHANGELOG.md` under the new version heading
+5. Resets `CHANGELOG-Unreleased.md` to empty section headers
+6. Syncs `docs-website/docs/docs/CHANGELOG.md`
+7. Opens a PR to `master` for review
+
+Run it from **master**: Actions → **Prepare Release** → Run workflow.
+
+### 2. `publish-release.yml` — Publish Release
+
+**Trigger:** Automatic when a `release/v*` PR is merged to `master`
+
+**What it does:**
+
+1. Builds the package (`yarn build` → `dist/`)
+2. Publishes `nitromelondb` to npm (`latest`, `alpha`, or `beta` dist-tag)
+3. Creates git tag `vX.Y.Z`
+4. Creates a GitHub Release (marked as prerelease for alpha/beta)
+5. Comments on the PR with npm and GitHub links
+
+## Release process
+
+```mermaid
+flowchart TD
+    Start([Start Release]) --> Manual1[/"👤 Step 1: Prepare Release<br/>(Actions → Prepare Release)"/]
+
+    Manual1 --> Action1["🔧 prepare-release.yml<br/>• Bump version<br/>• Roll CHANGELOG-Unreleased.md<br/>• Open release/vX.Y.Z PR"]
+
+    Action1 --> Manual2[/"👤 Step 2: Review and merge PR"/]
+
+    Manual2 --> Auto1["⚡ publish-release.yml<br/>• yarn build<br/>• npm publish ./dist<br/>• Tag + GitHub Release"]
+
+    Auto1 --> Done([✨ Release complete])
+```
+
+## Versioning
+
+`package.json` is currently `0.28.1-0` (an unpublished prerelease of 0.28.1). Typical first releases:
+
+| Current | Bump | Prerelease | Result |
+| --- | --- | --- | --- |
+| `0.28.1-0` | minor | alpha | `0.29.0-alpha.0` |
+| `0.28.1-0` | major | alpha | `1.0.0-alpha.0` |
+| `0.28.1-0` | minor | none | `0.29.0` |
+| `0.28.1-0` | patch | none | `0.28.1` |
+
+After that, repeating the same bump + channel increments the prerelease counter:
+
+| Current | Bump | Prerelease | Result |
+| --- | --- | --- | --- |
+| `0.29.0-alpha.0` | minor | alpha | `0.29.0-alpha.1` |
+| `0.29.0-alpha.1` | minor | beta | `0.29.0-beta.0` |
+| `0.29.0-beta.0` | minor | none | `0.29.0` |
+| `1.0.0-alpha.0` | major | alpha | `1.0.0-alpha.1` |
+| `1.0.0-alpha.2` | major | none | `1.0.0` |
+| `0.28.1` | patch | none | `0.28.2` |
+
+Repeating the **same** bump + channel increments `-alpha.N` / `-beta.N`. Choosing `none` on an in-progress prerelease publishes that core version as stable. A *different* bump starts a new core version (`0.29.0-alpha.0` + major + alpha → `1.0.0-alpha.0`).
+
+npm dist-tags:
+
+- stable → `latest`
+- `-alpha.N` → `alpha`
+- `-beta.N` → `beta`
+
+```bash
+npm install nitromelondb@latest
+npm install nitromelondb@alpha
+npm install nitromelondb@beta
+```
+
+Local check:
+
+```bash
+node scripts/next-version.mjs --self-test
+node scripts/next-version.mjs minor alpha
+```
+
+## Unreleased changelog
+
+Contributors add notes to `CHANGELOG-Unreleased.md`. Prepare Release copies non-empty sections into `CHANGELOG.md` as:
+
+```md
+## 0.29.0-alpha.0 - 2026-08-15
+
+### New features
+- ...
+```
+
+Empty section headers are dropped. The unreleased file is then reset for the next cycle.
+
+## npm trusted publishing (OIDC)
+
+Publishing does **not** use `NPM_TOKEN`. GitHub Actions authenticates to npm with a short-lived OIDC token ([trusted publishing](https://docs.npmjs.com/trusted-publishers/)).
+
+### One-time setup on npmjs.com
+
+`nitromelondb` must exist on npm before you can attach a trusted publisher. If it is not published yet, do **one** local bootstrap (2FA / OTP is fine here):
+
+```bash
+yarn build
+npm publish ./dist --access public --otp=123456
+```
+
+Then:
+
+1. Open [nitromelondb access settings](https://www.npmjs.com/package/nitromelondb/access)
+2. Under **Trusted Publisher**, choose **GitHub Actions**
+3. Fill in exactly:
+
+   | Field | Value |
+   | --- | --- |
+   | Organization or user | `StasDoskalenko` |
+   | Repository | `NitromelonDB` |
+   | Workflow filename | `publish-release.yml` |
+   | Environment name | *(leave empty)* |
+   | Allowed actions | `npm publish` |
+
+4. After the first Actions publish succeeds: Settings → **Publishing access** → **Require two-factor authentication and disallow tokens**. That blocks classic tokens; OIDC keeps working.
+
+Do not add an `NPM_TOKEN` secret to this repository.
+
+## Troubleshooting
+
+### Prepare Release refused to run
+- Select branch **master** when starting the workflow
+
+### PR not created
+- Check the Prepare Release run logs
+- Confirm `release/v…` does not already exist
+
+### npm publish did not run
+- PR must come from `release/vX.Y.Z` (or `-alpha.N` / `-beta.N`) in this repository
+- PR must be merged, not only closed
+
+### npm publish failed
+- Confirm the trusted publisher on npmjs.com matches `StasDoskalenko` / `NitromelonDB` / `publish-release.yml`
+- Confirm the workflow has `id-token: write` (it does in `publish-release.yml`)
+- Confirm that version is not already on npm
+- Review the Publish Release logs
+- `ENEEDAUTH` almost always means the workflow filename or repo name does not match the trusted publisher config (case-sensitive, include `.yml`)

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,181 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+      prerelease:
+        description: 'Prerelease channel (repeat alpha/beta increments -alpha.N / -beta.N)'
+        required: true
+        type: choice
+        options:
+          - none
+          - alpha
+          - beta
+        default: 'none'
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure workflow ran from master
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/master" ]; then
+            echo "❌ Run Prepare Release from the master branch (selected: ${{ github.ref_name }})"
+            exit 1
+          fi
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: Verify version calculator
+        run: node scripts/next-version.mjs --self-test
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Calculate new version
+        id: version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          NEW_VERSION=$(node scripts/next-version.mjs "${{ inputs.version_bump }}" "${{ inputs.prerelease }}" "$CURRENT_VERSION")
+
+          if [[ "$NEW_VERSION" == *-* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+          echo "IS_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_ENV"
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Bump: ${{ inputs.version_bump }} / prerelease: ${{ inputs.prerelease }}"
+          echo "✅ New version: $NEW_VERSION"
+
+      - name: Create release branch
+        run: |
+          BRANCH_NAME="release/v${{ env.NEW_VERSION }}"
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+            echo "❌ Branch $BRANCH_NAME already exists on origin"
+            exit 1
+          fi
+          git checkout -b "$BRANCH_NAME"
+          echo "PR_BRANCH=$BRANCH_NAME" >> "$GITHUB_ENV"
+          echo "✅ Branch created: $BRANCH_NAME"
+
+      - name: Update package.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = process.env.NEW_VERSION;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "✅ package.json updated to v${{ env.NEW_VERSION }}"
+
+      - name: Update docs-website version
+        if: env.IS_PRERELEASE == 'false'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('docs-website/package.json', 'utf8'));
+            pkg.version = process.env.NEW_VERSION;
+            fs.writeFileSync('docs-website/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "✅ docs-website/package.json updated to v${{ env.NEW_VERSION }}"
+
+      - name: Roll CHANGELOG-Unreleased.md into CHANGELOG.md
+        run: |
+          node scripts/prepare-changelog.mjs roll "${{ env.NEW_VERSION }}"
+          node scripts/prepare-changelog.mjs extract "${{ env.NEW_VERSION }}" > /tmp/release_notes.md
+          if [ ! -s /tmp/release_notes.md ]; then
+            echo "_No unreleased notes were recorded._" > /tmp/release_notes.md
+            echo "NOTES_EMPTY=true" >> "$GITHUB_ENV"
+          else
+            echo "NOTES_EMPTY=false" >> "$GITHUB_ENV"
+          fi
+          echo "✅ Changelog updated from CHANGELOG-Unreleased.md"
+
+      - name: Commit release files
+        run: |
+          git add package.json CHANGELOG.md CHANGELOG-Unreleased.md docs-website/docs/docs/CHANGELOG.md
+          if [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
+            git add docs-website/package.json
+          fi
+          git commit -m "chore: release v${{ env.NEW_VERSION }}"
+          git push origin "${{ env.PR_BRANCH }}"
+          echo "✅ Pushed ${{ env.PR_BRANCH }}"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "## Release v${{ env.NEW_VERSION }}"
+            echo ""
+            echo "This PR prepares **v${{ env.NEW_VERSION }}** (\`${{ inputs.version_bump }}\` / \`${{ inputs.prerelease }}\`)."
+            echo ""
+            echo "Previous version: \`${{ steps.version.outputs.current }}\`"
+            echo ""
+            echo "### Changes in this release"
+            echo ""
+            cat /tmp/release_notes.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "### What this PR does"
+            echo ""
+            echo "- Bumps \`package.json\` to \`${{ env.NEW_VERSION }}\`"
+            echo "- Moves \`CHANGELOG-Unreleased.md\` into \`CHANGELOG.md\`"
+            echo "- Resets \`CHANGELOG-Unreleased.md\` for the next cycle"
+            if [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
+              echo "- Bumps \`docs-website/package.json\` to \`${{ env.NEW_VERSION }}\`"
+            fi
+            echo ""
+            echo "**Merging this PR will:**"
+            echo "- Create git tag \`v${{ env.NEW_VERSION }}\`"
+            echo "- Create a GitHub Release"
+            if [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
+              echo "- Publish \`nitromelondb@${{ env.NEW_VERSION }}\` to npm with dist-tag \`${{ inputs.prerelease }}\`"
+            else
+              echo "- Publish \`nitromelondb@${{ env.NEW_VERSION }}\` to npm with dist-tag \`latest\`"
+            fi
+          } > /tmp/pr_body.md
+
+          gh pr create \
+            --base master \
+            --head "${{ env.PR_BRANCH }}" \
+            --title "Release v${{ env.NEW_VERSION }}" \
+            --body-file /tmp/pr_body.md
+
+          echo "✅ Pull request created"
+
+      - name: Summary
+        run: |
+          echo "🎉 Release PR prepared for v${{ env.NEW_VERSION }}"
+          echo ""
+          echo "Review and merge the PR. Publishing (tag, GitHub Release, npm) runs automatically after merge."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,158 @@
+name: Publish Release
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - master
+
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Validate release branch
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          if [[ ! "$BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+            echo "❌ Branch name '$BRANCH' doesn't match release/vX.Y.Z or release/vX.Y.Z-alpha.N / -beta.N"
+            exit 1
+          fi
+          echo "✅ Valid release branch: $BRANCH"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-alpha."* ]]; then
+            DIST_TAG=alpha
+            IS_PRERELEASE=true
+          elif [[ "$VERSION" == *"-beta."* ]]; then
+            DIST_TAG=beta
+            IS_PRERELEASE=true
+          else
+            DIST_TAG=latest
+            IS_PRERELEASE=false
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "NEW_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
+          echo "IS_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_ENV"
+          echo "📦 Version: $VERSION (npm tag: $DIST_TAG)"
+
+      - name: Extract release notes
+        run: |
+          if ! node scripts/prepare-changelog.mjs extract "${{ env.NEW_VERSION }}" > /tmp/release_notes.md; then
+            echo "See the changelog for details." > /tmp/release_notes.md
+          fi
+          if [ ! -s /tmp/release_notes.md ]; then
+            echo "See the changelog for details." > /tmp/release_notes.md
+          fi
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: 'node_modules'
+          key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build package
+        run: yarn build
+
+      - name: Publish to npm
+        run: |
+          unset NODE_AUTH_TOKEN
+          if npm view "nitromelondb@${{ env.NEW_VERSION }}" version >/dev/null 2>&1; then
+            echo "nitromelondb@${{ env.NEW_VERSION }} is already on npm, skipping publish"
+          else
+            npm publish ./dist --access public --tag "${{ env.DIST_TAG }}"
+            echo "✅ Published nitromelondb@${{ env.NEW_VERSION }} with tag ${{ env.DIST_TAG }}"
+          fi
+
+      - name: Create git tag
+        run: |
+          TAG="v${{ env.NEW_VERSION }}"
+          git fetch --tags
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping create"
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+            echo "✅ Tag created: $TAG"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ env.NEW_VERSION }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists, skipping create"
+          elif [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/release_notes.md --prerelease
+            echo "✅ GitHub Release created: $TAG (prerelease)"
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/release_notes.md
+            echo "✅ GitHub Release created: $TAG"
+          fi
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body \
+            "🎉 **nitromelondb@${{ env.NEW_VERSION }} published**
+
+          📦 **npm:** [nitromelondb@${{ env.NEW_VERSION }}](https://www.npmjs.com/package/nitromelondb/v/${{ env.NEW_VERSION }}) (\`${{ env.DIST_TAG }}\`)
+          🔖 **Release:** [v${{ env.NEW_VERSION }}](https://github.com/${{ github.repository }}/releases/tag/v${{ env.NEW_VERSION }})
+
+          Install with:
+          \`\`\`bash
+          npm install nitromelondb@${{ env.NEW_VERSION }}
+          # or
+          yarn add nitromelondb@${{ env.NEW_VERSION }}
+          \`\`\`"
+
+          echo "✅ PR comment posted"
+
+      - name: Summary
+        run: |
+          echo "🎉 Release v${{ env.NEW_VERSION }} complete!"
+          echo "✅ npm: https://www.npmjs.com/package/nitromelondb/v/${{ env.NEW_VERSION }}"
+          echo "✅ Release: https://github.com/${{ github.repository }}/releases/tag/v${{ env.NEW_VERSION }}"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ msbuild.binlog
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Local GitHub Actions secrets for `act` (never commit)
+.secrets
+.github/workflows/.secrets

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -2,59 +2,14 @@
 
 ### BREAKING CHANGES
 
-- Minimum supported Node.js version is now 22.x (required by React Native 0.87)
-- [iOS] Minimum deployment target is now iOS 15.1
-- [Android] Minimum SDK version is now 24
-- [iOS] CocoaPods spec renamed from `WatermelonDB` to `NitromelonDB`. Autolinking picks up the pod. Bridging-header imports, if you have them, are `#import <NitromelonDB/WatermelonDB.h>`.
-- [iOS] `simdjson` is vendored in `native/vendor/simdjson` and compiled into the `NitromelonDB` pod. Remove any hand-copied `pod 'simdjson'` Podfile lines; do not add `pod 'NitromelonDB'` either.
-- [SQLite][RN] iOS/Android SQLite is Nitro-only. NativeModules interop (`{ jsi: false }`) is removed. The old React Native architecture (Paper / the legacy bridge) is not supported. Windows still uses the JSI installer. Web and Electron keep the Node/better-sqlite3 dispatcher (`makeDispatcher/index.ts` / `index.web.ts`).
-- [SQLite][RN] Removed the leftover NativeModule SQLite stack: iOS `WMDatabaseBridge` / `WMDatabaseDriver` / FMDB, and the Android Java `WMDatabaseBridge` / `WMDatabase` / `WMDatabaseDriver` APIs. Random IDs use `Nitromelon.getRandomIds()` on Nitro. Android `WatermelonDBPackage` still installs the database path and closes SQLite on JS reload.
-- [Android] Removed `native/android-jsi` (`WatermelonDBJSIPackage`, `libwatermelondb-jsi.so`). Drop `include ':watermelondb-jsi'` and `WatermelonDBJSIPackage` from the app. Nitro autolinks. Native turbo-sync JSON injection uses `com.nozbe.watermelondb.NitromelonNative.provideSyncJson`.
-- [Nitro] The `NitromelonDatabase` HybridObject now exposes the full SQLite adapter API (`initialize`, `find`, `query`, `batchJSON`, …) as typed Nitrogen methods. The `ping()` / `nativeEngine` smoke-test API is removed. iOS/Android no longer install `nativeWatermelonCreateAdapter` JSI bindings.
-- The npm package is now `nitromelondb` (was `@nozbe/watermelondb`). Update install commands and imports (`yarn add nitromelondb`, `import { Database } from 'nitromelondb'`).
-
 ### Deprecations
 
 ### New features
 
-- [Database] `new Database({ experimentalDetectNestedWriters: true })` throws immediately when a reader/writer is called from another without `callWriter()`/`callReader()`, instead of deadlocking. Detection covers the same JS turn and the continuation after Watermelon adapter awaits (`find` / `query` / `batch`).
-- [Electron] Added `RemoteAdapter` so SQLite can run in Electron's main process over IPC (or any serializable transport). Cherry-picked from [Nozbe/WatermelonDB#1859](https://github.com/Nozbe/WatermelonDB/pull/1859) by [@feznyng](https://github.com/feznyng)
-- [Expo] First-class Expo support: config plugin (`app.plugin.js`) for development builds, EAS Build, and EAS Update. Add `"nitromelondb"` to `app.json` `plugins`. Replaces `@morrowdigital/watermelondb-expo-plugin` (Android JSI wiring is not used; SQLite is Nitro). Optional `{ "excludeSimArch": true }`.
-
 ### Fixes
-
-- [LokiJS] Multitab sync issue fix
-- [Android] Added linker flag for building with 16kB page alignment
-- [Android] Generate `BuildConfig` under AGP 8+ (fixes `cannot find symbol: BuildConfig`)
-- [TS] make catchError visible to typescript
 
 ### Performance
 
 ### Changes
 
-- [Nitro] Native SQLite uses a typed `NitromelonDatabase` HybridObject wrapping the existing C++ `Database`. `react-native-nitro-modules` is an optional peer dependency. The Expo SDK 57 app in `examples/nitro` uses `SQLiteAdapter` with a notes schema, migrations, and a list UI.
-- Migrated the JS source from Flow + hand-written `.d.ts` to TypeScript. Implementation under `src/` is now TypeScript, including adapters (SQLite, LokiJS, remote). `yarn typecheck` uses `strict`, `noUnusedLocals`, `noUnusedParameters`, and `exactOptionalPropertyTypes`, and forbids explicit `any`. Tests remain JavaScript.
-
-- ESLint and TypeScript are dedicated required CI jobs on every pull request. Implementation files under `src/` must be TypeScript (JavaScript is only allowed in tests). ESLint uses `@typescript-eslint/recommended` rather than turning core JS rules off by hand.
-- Removed the Flow toolchain: `flow-bin`, `eslint-plugin-flowtype`, Babel Flow plugins, `.flowconfig`, and `flow-typed`.
-- Metro strips TypeScript for `.ts` sources, and `yarn test:metro-transform` guards that path in CI.
-
-- Updated better-sqlite3 to 13.0.3
-- Support for React Native 0.87 and React 19
-- Added a [Migrating from WatermelonDB](./docs-website/docs/docs/Migrating.md) guide to the docs site
-- Publish docs to GitHub Pages at https://stasdoskalenko.github.io/NitromelonDB/ (docs index: https://stasdoskalenko.github.io/NitromelonDB/docs)
-- [iOS] `simdjson` is vendored in `native/vendor/simdjson` and compiled into the `NitromelonDB` pod. Autolinking is enough; remove any hand-copied `pod 'simdjson'` Podfile lines.
-- Dropped the `@nozbe/simdjson` npm dependency. Native builds compile the official amalgamation from this repo.
-- Dropped the `@nozbe/sqlite` npm dependency. Android and Windows compile the official amalgamation from `native/vendor/sqlite`; iOS still links the system sqlite3.
-
 ### Internal
-
-- Updated internal dependencies
-- Updated documentation scripts
-- [CI] Run JavaScript tests on Node.js 24 only
-- [CI] Run iOS tests on macOS 26 / latest stable Xcode / iPhone 17 (iOS 26)
-- [CI] Android tests use JDK 21
-- [CI] Use latest CocoaPods (1.17) without the old 1.15 / xcodeproj / ethon pins
-- Bundle React Native 0.87 with its own Babel preset
-- [CI] Weekly `simdjson` bump workflow opens a PR when a newer official amalgamation is available (`scripts/vendor-simdjson.mjs`)
-- [CI] Weekly `sqlite` bump workflow opens a PR when a newer official amalgamation is available (`scripts/vendor-sqlite.mjs`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to this project will be documented in this file.
 
 Contributors: Please add your changes to CHANGELOG-Unreleased.md
 
+## 0.30.0-alpha.0 - 2026-08-15
+
+### BREAKING CHANGES
+
+- Minimum supported Node.js version is now 22.x (required by React Native 0.87)
+- [iOS] Minimum deployment target is now iOS 15.1
+- [Android] Minimum SDK version is now 24
+- [iOS] CocoaPods spec renamed from `WatermelonDB` to `NitromelonDB`. Autolinking picks up the pod. Bridging-header imports, if you have them, are `#import <NitromelonDB/WatermelonDB.h>`.
+- [iOS] `simdjson` is vendored in `native/vendor/simdjson` and compiled into the `NitromelonDB` pod. Remove any hand-copied `pod 'simdjson'` Podfile lines; do not add `pod 'NitromelonDB'` either.
+- [SQLite][RN] iOS/Android SQLite is Nitro-only. NativeModules interop (`{ jsi: false }`) is removed. The old React Native architecture (Paper / the legacy bridge) is not supported. Windows still uses the JSI installer. Web and Electron keep the Node/better-sqlite3 dispatcher (`makeDispatcher/index.ts` / `index.web.ts`).
+- [SQLite][RN] Removed the leftover NativeModule SQLite stack: iOS `WMDatabaseBridge` / `WMDatabaseDriver` / FMDB, and the Android Java `WMDatabaseBridge` / `WMDatabase` / `WMDatabaseDriver` APIs. Random IDs use `Nitromelon.getRandomIds()` on Nitro. Android `WatermelonDBPackage` still installs the database path and closes SQLite on JS reload.
+- [Android] Removed `native/android-jsi` (`WatermelonDBJSIPackage`, `libwatermelondb-jsi.so`). Drop `include ':watermelondb-jsi'` and `WatermelonDBJSIPackage` from the app. Nitro autolinks. Native turbo-sync JSON injection uses `com.nozbe.watermelondb.NitromelonNative.provideSyncJson`.
+- [Nitro] The `NitromelonDatabase` HybridObject now exposes the full SQLite adapter API (`initialize`, `find`, `query`, `batchJSON`, …) as typed Nitrogen methods. The `ping()` / `nativeEngine` smoke-test API is removed. iOS/Android no longer install `nativeWatermelonCreateAdapter` JSI bindings.
+- The npm package is now `nitromelondb` (was `@nozbe/watermelondb`). Update install commands and imports (`yarn add nitromelondb`, `import { Database } from 'nitromelondb'`).
+
+### New features
+
+- [Database] `new Database({ experimentalDetectNestedWriters: true })` throws immediately when a reader/writer is called from another without `callWriter()`/`callReader()`, instead of deadlocking. Detection covers the same JS turn and the continuation after Watermelon adapter awaits (`find` / `query` / `batch`).
+- [Electron] Added `RemoteAdapter` so SQLite can run in Electron's main process over IPC (or any serializable transport). Cherry-picked from [Nozbe/WatermelonDB#1859](https://github.com/Nozbe/WatermelonDB/pull/1859) by [@feznyng](https://github.com/feznyng)
+- [Expo] First-class Expo support: config plugin (`app.plugin.js`) for development builds, EAS Build, and EAS Update. Add `"nitromelondb"` to `app.json` `plugins`. Replaces `@morrowdigital/watermelondb-expo-plugin` (Android JSI wiring is not used; SQLite is Nitro). Optional `{ "excludeSimArch": true }`.
+
+### Fixes
+
+- [LokiJS] Multitab sync issue fix
+- [Android] Added linker flag for building with 16kB page alignment
+- [Android] Generate `BuildConfig` under AGP 8+ (fixes `cannot find symbol: BuildConfig`)
+- [TS] make catchError visible to typescript
+
+### Changes
+
+- [Nitro] Native SQLite uses a typed `NitromelonDatabase` HybridObject wrapping the existing C++ `Database`. `react-native-nitro-modules` is an optional peer dependency. The Expo SDK 57 app in `examples/nitro` uses `SQLiteAdapter` with a notes schema, migrations, and a list UI.
+- Migrated the JS source from Flow + hand-written `.d.ts` to TypeScript. Implementation under `src/` is now TypeScript, including adapters (SQLite, LokiJS, remote). `yarn typecheck` uses `strict`, `noUnusedLocals`, `noUnusedParameters`, and `exactOptionalPropertyTypes`, and forbids explicit `any`. Tests remain JavaScript.
+
+- ESLint and TypeScript are dedicated required CI jobs on every pull request. Implementation files under `src/` must be TypeScript (JavaScript is only allowed in tests). ESLint uses `@typescript-eslint/recommended` rather than turning core JS rules off by hand.
+- Removed the Flow toolchain: `flow-bin`, `eslint-plugin-flowtype`, Babel Flow plugins, `.flowconfig`, and `flow-typed`.
+- Metro strips TypeScript for `.ts` sources, and `yarn test:metro-transform` guards that path in CI.
+
+- Updated better-sqlite3 to 13.0.3
+- Support for React Native 0.87 and React 19
+- Added a [Migrating from WatermelonDB](./docs-website/docs/docs/Migrating.md) guide to the docs site
+- Publish docs to GitHub Pages at https://stasdoskalenko.github.io/NitromelonDB/ (docs index: https://stasdoskalenko.github.io/NitromelonDB/docs)
+- [iOS] `simdjson` is vendored in `native/vendor/simdjson` and compiled into the `NitromelonDB` pod. Autolinking is enough; remove any hand-copied `pod 'simdjson'` Podfile lines.
+- Dropped the `@nozbe/simdjson` npm dependency. Native builds compile the official amalgamation from this repo.
+- Dropped the `@nozbe/sqlite` npm dependency. Android and Windows compile the official amalgamation from `native/vendor/sqlite`; iOS still links the system sqlite3.
+
+### Internal
+
+- Added GitHub Actions release workflows (Prepare Release / Publish Release) with alpha and beta channels. Notes in `CHANGELOG-Unreleased.md` are rolled into the release automatically. npm publish uses OIDC trusted publishing (no `NPM_TOKEN`).
+- Updated internal dependencies
+- Updated documentation scripts
+- [CI] Run JavaScript tests on Node.js 24 only
+- [CI] Run iOS tests on macOS 26 / latest stable Xcode / iPhone 17 (iOS 26)
+- [CI] Android tests use JDK 21
+- [CI] Use latest CocoaPods (1.17) without the old 1.15 / xcodeproj / ethon pins
+- Bundle React Native 0.87 with its own Babel preset
+- [CI] Weekly `simdjson` bump workflow opens a PR when a newer official amalgamation is available (`scripts/vendor-simdjson.mjs`)
+- [CI] Weekly `sqlite` bump workflow opens a PR when a newer official amalgamation is available (`scripts/vendor-sqlite.mjs`)
+
 ## 0.28 - 2025-04-07
 
 ### BREAKING CHANGES

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ If you make or are considering making an app using NitromelonDB, please let us k
    ```bash
    yarn prettier
    ```
-4. Mark your changes in CHANGELOG
+4. Mark your changes in `CHANGELOG-Unreleased.md`
 
-   Put a one-line description of your change under Added/Changed section. See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+   Put a one-line description under the matching section (New features, Fixes, Changes, …). Those notes are copied into `CHANGELOG.md` automatically when a release is prepared. See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Running Watermelon in development
 

--- a/docs-website/docs/docs/CHANGELOG.md
+++ b/docs-website/docs/docs/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to this project will be documented in this file.
 
 Contributors: Please add your changes to CHANGELOG-Unreleased.md
 
+## 0.30.0-alpha.0 - 2026-08-15
+
+### BREAKING CHANGES
+
+- Minimum supported Node.js version is now 22.x (required by React Native 0.87)
+- [iOS] Minimum deployment target is now iOS 15.1
+- [Android] Minimum SDK version is now 24
+- [iOS] CocoaPods spec renamed from `WatermelonDB` to `NitromelonDB`. Autolinking picks up the pod. Bridging-header imports, if you have them, are `#import &lt;NitromelonDB/WatermelonDB.h>`.
+- [iOS] `simdjson` is vendored in `native/vendor/simdjson` and compiled into the `NitromelonDB` pod. Remove any hand-copied `pod 'simdjson'` Podfile lines; do not add `pod 'NitromelonDB'` either.
+- [SQLite][RN] iOS/Android SQLite is Nitro-only. NativeModules interop (`{ jsi: false }`) is removed. The old React Native architecture (Paper / the legacy bridge) is not supported. Windows still uses the JSI installer. Web and Electron keep the Node/better-sqlite3 dispatcher (`makeDispatcher/index.ts` / `index.web.ts`).
+- [SQLite][RN] Removed the leftover NativeModule SQLite stack: iOS `WMDatabaseBridge` / `WMDatabaseDriver` / FMDB, and the Android Java `WMDatabaseBridge` / `WMDatabase` / `WMDatabaseDriver` APIs. Random IDs use `Nitromelon.getRandomIds()` on Nitro. Android `WatermelonDBPackage` still installs the database path and closes SQLite on JS reload.
+- [Android] Removed `native/android-jsi` (`WatermelonDBJSIPackage`, `libwatermelondb-jsi.so`). Drop `include ':watermelondb-jsi'` and `WatermelonDBJSIPackage` from the app. Nitro autolinks. Native turbo-sync JSON injection uses `com.nozbe.watermelondb.NitromelonNative.provideSyncJson`.
+- [Nitro] The `NitromelonDatabase` HybridObject now exposes the full SQLite adapter API (`initialize`, `find`, `query`, `batchJSON`, …) as typed Nitrogen methods. The `ping()` / `nativeEngine` smoke-test API is removed. iOS/Android no longer install `nativeWatermelonCreateAdapter` JSI bindings.
+- The npm package is now `nitromelondb` (was `@nozbe/watermelondb`). Update install commands and imports (`yarn add nitromelondb`, `import { Database } from 'nitromelondb'`).
+
+### New features
+
+- [Database] `new Database({ experimentalDetectNestedWriters: true })` throws immediately when a reader/writer is called from another without `callWriter()`/`callReader()`, instead of deadlocking. Detection covers the same JS turn and the continuation after Watermelon adapter awaits (`find` / `query` / `batch`).
+- [Electron] Added `RemoteAdapter` so SQLite can run in Electron's main process over IPC (or any serializable transport). Cherry-picked from [Nozbe/WatermelonDB#1859](https://github.com/Nozbe/WatermelonDB/pull/1859) by [@feznyng](https://github.com/feznyng)
+- [Expo] First-class Expo support: config plugin (`app.plugin.js`) for development builds, EAS Build, and EAS Update. Add `"nitromelondb"` to `app.json` `plugins`. Replaces `@morrowdigital/watermelondb-expo-plugin` (Android JSI wiring is not used; SQLite is Nitro). Optional `{ "excludeSimArch": true }`.
+
+### Fixes
+
+- [LokiJS] Multitab sync issue fix
+- [Android] Added linker flag for building with 16kB page alignment
+- [Android] Generate `BuildConfig` under AGP 8+ (fixes `cannot find symbol: BuildConfig`)
+- [TS] make catchError visible to typescript
+
+### Changes
+
+- [Nitro] Native SQLite uses a typed `NitromelonDatabase` HybridObject wrapping the existing C++ `Database`. `react-native-nitro-modules` is an optional peer dependency. The Expo SDK 57 app in `examples/nitro` uses `SQLiteAdapter` with a notes schema, migrations, and a list UI.
+- Migrated the JS source from Flow + hand-written `.d.ts` to TypeScript. Implementation under `src/` is now TypeScript, including adapters (SQLite, LokiJS, remote). `yarn typecheck` uses `strict`, `noUnusedLocals`, `noUnusedParameters`, and `exactOptionalPropertyTypes`, and forbids explicit `any`. Tests remain JavaScript.
+
+- ESLint and TypeScript are dedicated required CI jobs on every pull request. Implementation files under `src/` must be TypeScript (JavaScript is only allowed in tests). ESLint uses `@typescript-eslint/recommended` rather than turning core JS rules off by hand.
+- Removed the Flow toolchain: `flow-bin`, `eslint-plugin-flowtype`, Babel Flow plugins, `.flowconfig`, and `flow-typed`.
+- Metro strips TypeScript for `.ts` sources, and `yarn test:metro-transform` guards that path in CI.
+
+- Updated better-sqlite3 to 13.0.3
+- Support for React Native 0.87 and React 19
+- Added a [Migrating from WatermelonDB](./Migrating.md) guide to the docs site
+- Publish docs to GitHub Pages at https://stasdoskalenko.github.io/NitromelonDB/ (docs index: https://stasdoskalenko.github.io/NitromelonDB/docs)
+- [iOS] `simdjson` is vendored in `native/vendor/simdjson` and compiled into the `NitromelonDB` pod. Autolinking is enough; remove any hand-copied `pod 'simdjson'` Podfile lines.
+- Dropped the `@nozbe/simdjson` npm dependency. Native builds compile the official amalgamation from this repo.
+- Dropped the `@nozbe/sqlite` npm dependency. Android and Windows compile the official amalgamation from `native/vendor/sqlite`; iOS still links the system sqlite3.
+
+### Internal
+
+- Added GitHub Actions release workflows (Prepare Release / Publish Release) with alpha and beta channels. Notes in `CHANGELOG-Unreleased.md` are rolled into the release automatically. npm publish uses OIDC trusted publishing (no `NPM_TOKEN`).
+- Updated internal dependencies
+- Updated documentation scripts
+- [CI] Run JavaScript tests on Node.js 24 only
+- [CI] Run iOS tests on macOS 26 / latest stable Xcode / iPhone 17 (iOS 26)
+- [CI] Android tests use JDK 21
+- [CI] Use latest CocoaPods (1.17) without the old 1.15 / xcodeproj / ethon pins
+- Bundle React Native 0.87 with its own Babel preset
+- [CI] Weekly `simdjson` bump workflow opens a PR when a newer official amalgamation is available (`scripts/vendor-simdjson.mjs`)
+- [CI] Weekly `sqlite` bump workflow opens a PR when a newer official amalgamation is available (`scripts/vendor-sqlite.mjs`)
+
 ## 0.28 - 2025-04-07
 
 ### BREAKING CHANGES

--- a/docs-website/docs/docs/Implementation/Publishing.md
+++ b/docs-website/docs/docs/Implementation/Publishing.md
@@ -1,32 +1,57 @@
-# Publishing WatermelonDB
+# Publishing NitromelonDB
 
-### Step 1: Run all automated tests
+Releases are done with GitHub Actions. Do not publish to npm from your laptop.
+
+Full details: [`.github/workflows/README.md`](https://github.com/StasDoskalenko/NitromelonDB/blob/master/.github/workflows/README.md).
+
+### Step 1: Keep `CHANGELOG-Unreleased.md` current
+
+Every merged change should already have a note there. Prepare Release copies those notes into `CHANGELOG.md` automatically.
+
+### Step 2: Prepare the release
+
+1. GitHub → **Actions** → **Prepare Release**
+2. Run the workflow from **master**
+3. Choose:
+   - **Version bump:** `patch` / `minor` / `major`
+   - **Prerelease:** `none` / `alpha` / `beta`
+
+Repeat alpha/beta releases of the same version increment the counter (`0.29.0-alpha.0`, then `0.29.0-alpha.1`). Choosing `none` on an in-progress prerelease publishes that version as stable.
+
+### Step 3: Review and merge the PR
+
+The workflow opens a `release/v…` PR with the version bump and changelog. CI runs on that PR. Merge when it looks right.
+
+### Step 4: Automatic publish
+
+Merging the PR:
+
+- Builds `dist/`
+- Publishes `nitromelondb` to npm (`latest`, `alpha`, or `beta`)
+- Creates the git tag and GitHub Release
+
+### Local helpers
 
 ```bash
-yarn ci:check && yarn test:ios && yarn test:android && yarn ktlint
+# Preview the next version without changing files
+node scripts/next-version.mjs minor alpha
+
+# Version calculator tests
+node scripts/next-version.mjs --self-test
 ```
 
-### Step 2: Test manually in a real app
+The interactive `yarn release` script is legacy. Use Actions instead.
 
-```bash
-yarn build
-```
+### npm authentication
 
-Then copy `dist/` and replace `app/node_modules/nitromelondb` with it.
+No `NPM_TOKEN` secret. Releases authenticate with [npm trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/).
 
-If a quick smoke test passes, proceed to publish.
+One-time: if `nitromelondb` is not on npm yet, publish once from your machine (`yarn build && npm publish ./dist --otp=…`), then on [package access settings](https://www.npmjs.com/package/nitromelondb/access) add a GitHub Actions trusted publisher:
 
-### Step 3: Update CHANGELOG
+- Organization or user: `StasDoskalenko`
+- Repository: `NitromelonDB`
+- Workflow filename: `publish-release.yml` (filename only)
+- Environment: leave empty
+- Allowed actions: `npm publish`
 
-Change `Unreleased` header to the new version, add new Unreleased
-
-### Step 4: Publish
-
-```bash
-npm run release
-
-# skips checks (only use on prerelease)
-npm run release --skip-checks
-```
-
-Don't use `yarn release` (or `yarn publish`) — it won't work (yarn doesn't support NPM 2FA).
+After the first Actions publish works, set **Require two-factor authentication and disallow tokens** on that same page. Details: [`.github/workflows/README.md`](https://github.com/StasDoskalenko/NitromelonDB/blob/master/.github/workflows/README.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nitromelondb",
   "description": "Reactive SQLite database for React Native and React web. A maintained fork of WatermelonDB.",
-  "version": "0.28.1-0",
+  "version": "0.30.0-alpha.0",
   "engines": {
     "node": ">=22"
   },

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Compute the next NitromelonDB version from a semver bump + optional prerelease channel.
+ *
+ * Usage:
+ *   node scripts/next-version.mjs <patch|minor|major> <none|alpha|beta> [currentVersion]
+ *   node scripts/next-version.mjs --self-test
+ *
+ * Repeat alpha/beta releases of the same in-progress version increment the prerelease
+ * counter (1.0.0-alpha.0 → 1.0.0-alpha.1). Switching channel resets it (alpha → beta.0).
+ * Choosing `none` on a prerelease publishes that core version as stable.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const BUMPS = new Set(['patch', 'minor', 'major'])
+const PREIDS = new Set(['none', 'alpha', 'beta'])
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(?:\.(\d+))?|-(\d+))?$/
+
+export function parseVersion(version) {
+  const match = VERSION_RE.exec(version)
+  if (!match) {
+    throw new Error(`Invalid version: ${version}`)
+  }
+
+  const preid = match[4] ?? null
+  const prenum =
+    match[5] !== undefined ? Number(match[5]) : match[6] !== undefined ? Number(match[6]) : null
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    preid,
+    prenum,
+    hasPrerelease: version.includes('-'),
+  }
+}
+
+function formatCore({ major, minor, patch }) {
+  return `${major}.${minor}.${patch}`
+}
+
+function bumpCore(parsed, bump) {
+  switch (bump) {
+    case 'major':
+      return { major: parsed.major + 1, minor: 0, patch: 0 }
+    case 'minor':
+      return { major: parsed.major, minor: parsed.minor + 1, patch: 0 }
+    case 'patch':
+      return { major: parsed.major, minor: parsed.minor, patch: parsed.patch + 1 }
+    default:
+      throw new Error(`Invalid bump: ${bump}`)
+  }
+}
+
+/**
+ * Stay on the current X.Y.Z when repeating a prerelease of the version that bump
+ * originally produced:
+ *   1.0.0-alpha.0 + major + alpha → 1.0.0-alpha.1
+ *   0.29.0-alpha.0 + minor + alpha → 0.29.0-alpha.1
+ *   0.28.2-alpha.0 + patch + alpha → 0.28.2-alpha.1
+ *
+ * A different bump starts a new core version:
+ *   0.29.0-alpha.0 + major + alpha → 1.0.0-alpha.0
+ *   1.0.0-alpha.0 + minor + alpha → 1.1.0-alpha.0
+ */
+function shouldStayOnCurrentCore(parsed, bump) {
+  if (bump === 'major') {
+    return parsed.minor === 0 && parsed.patch === 0
+  }
+  if (bump === 'minor') {
+    return parsed.patch === 0 && parsed.minor !== 0
+  }
+  return parsed.patch !== 0
+}
+
+export function nextVersion(current, bump, preid) {
+  if (!BUMPS.has(bump)) {
+    throw new Error(`Invalid bump: ${bump}`)
+  }
+  if (!PREIDS.has(preid)) {
+    throw new Error(`Invalid prerelease: ${preid}`)
+  }
+
+  const parsed = parseVersion(current)
+  const currentCore = formatCore(parsed)
+
+  let targetCore = currentCore
+  if (!parsed.hasPrerelease) {
+    targetCore = formatCore(bumpCore(parsed, bump))
+  } else if (!shouldStayOnCurrentCore(parsed, bump)) {
+    targetCore = formatCore(bumpCore(parsed, bump))
+  }
+
+  if (preid === 'none') {
+    return targetCore
+  }
+
+  const sameLine = currentCore === targetCore && parsed.preid === preid
+  if (sameLine) {
+    const nextNum = (parsed.prenum ?? -1) + 1
+    return `${targetCore}-${preid}.${nextNum < 0 ? 0 : nextNum}`
+  }
+
+  return `${targetCore}-${preid}.0`
+}
+
+const SELF_TESTS = [
+  ['0.28.1', 'major', 'none', '1.0.0'],
+  ['0.28.1', 'major', 'alpha', '1.0.0-alpha.0'],
+  ['0.28.1', 'minor', 'alpha', '0.29.0-alpha.0'],
+  ['0.28.1', 'patch', 'none', '0.28.2'],
+  ['0.28.1', 'patch', 'alpha', '0.28.2-alpha.0'],
+  ['1.0.0-alpha.0', 'major', 'alpha', '1.0.0-alpha.1'],
+  ['1.0.0-alpha.1', 'major', 'alpha', '1.0.0-alpha.2'],
+  ['1.0.0-alpha.2', 'major', 'beta', '1.0.0-beta.0'],
+  ['1.0.0-beta.0', 'major', 'beta', '1.0.0-beta.1'],
+  ['1.0.0-beta.0', 'major', 'none', '1.0.0'],
+  ['1.0.0-alpha.2', 'major', 'none', '1.0.0'],
+  ['0.29.0-alpha.0', 'minor', 'alpha', '0.29.0-alpha.1'],
+  ['0.29.0-alpha.1', 'minor', 'none', '0.29.0'],
+  ['0.29.0-alpha.0', 'major', 'alpha', '1.0.0-alpha.0'],
+  ['0.28.2-alpha.0', 'patch', 'alpha', '0.28.2-alpha.1'],
+  ['0.28.2-alpha.0', 'patch', 'none', '0.28.2'],
+  ['0.28.1-0', 'minor', 'alpha', '0.29.0-alpha.0'],
+  ['0.28.1-0', 'patch', 'none', '0.28.1'],
+  ['0.28.1-0', 'major', 'alpha', '1.0.0-alpha.0'],
+  ['0.28.1-0', 'minor', 'none', '0.29.0'],
+  ['1.0.0', 'minor', 'beta', '1.1.0-beta.0'],
+  ['1.1.0-beta.0', 'minor', 'beta', '1.1.0-beta.1'],
+  ['1.0.0-alpha.0', 'minor', 'alpha', '1.1.0-alpha.0'],
+  ['1.0.0-alpha.0', 'patch', 'alpha', '1.0.1-alpha.0'],
+  ['0.29.0-alpha.0', 'patch', 'alpha', '0.29.1-alpha.0'],
+]
+
+function readCurrentVersion() {
+  const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'package.json')
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  return pkg.version
+}
+
+function runSelfTest() {
+  let failed = 0
+  for (const [current, bump, preid, expected] of SELF_TESTS) {
+    const actual = nextVersion(current, bump, preid)
+    if (actual !== expected) {
+      failed += 1
+      console.error(`FAIL  ${current} + ${bump} + ${preid} → ${actual} (expected ${expected})`)
+    } else {
+      console.log(`ok    ${current} + ${bump} + ${preid} → ${actual}`)
+    }
+  }
+  if (failed) {
+    console.error(`\n${failed} test(s) failed`)
+    process.exit(1)
+  }
+  console.log(`\n${SELF_TESTS.length} tests passed`)
+}
+
+function main(argv) {
+  if (argv[0] === '--self-test') {
+    runSelfTest()
+    return
+  }
+
+  const bump = argv[0]
+  const preid = argv[1]
+  const current = argv[2] || readCurrentVersion()
+
+  if (!bump || !preid) {
+    console.error('Usage: node scripts/next-version.mjs <patch|minor|major> <none|alpha|beta> [currentVersion]')
+    process.exit(1)
+  }
+
+  const version = nextVersion(current, bump, preid)
+  console.log(version)
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isDirectRun) {
+  main(process.argv.slice(2))
+}

--- a/scripts/prepare-changelog.mjs
+++ b/scripts/prepare-changelog.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Roll CHANGELOG-Unreleased.md into CHANGELOG.md for a release, or extract notes.
+ *
+ * Usage:
+ *   node scripts/prepare-changelog.mjs roll <version>
+ *   node scripts/prepare-changelog.mjs extract <version>
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const CHANGELOG_PATH = path.join(ROOT, 'CHANGELOG.md')
+const UNRELEASED_PATH = path.join(ROOT, 'CHANGELOG-Unreleased.md')
+const DOCS_CHANGELOG_PATH = path.join(ROOT, 'docs-website/docs/docs/CHANGELOG.md')
+
+const UNRELEASED_TEMPLATE = `### Highlights
+
+### BREAKING CHANGES
+
+### Deprecations
+
+### New features
+
+### Fixes
+
+### Performance
+
+### Changes
+
+### Internal
+`
+
+function stripEmptySections(markdown) {
+  const parts = markdown.split(/^(?=### )/m)
+  const kept = parts
+    .map((section) => section.trim())
+    .filter((section) => {
+      if (!section) {
+        return false
+      }
+      if (!section.startsWith('### ')) {
+        return true
+      }
+      const body = section.split('\n').slice(1).join('\n').trim()
+      return body.length > 0
+    })
+  return `${kept.join('\n\n')}\n`
+}
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function rollChangelog(version, { date = todayUtc() } = {}) {
+  if (!fs.existsSync(UNRELEASED_PATH)) {
+    throw new Error('CHANGELOG-Unreleased.md is missing')
+  }
+  if (!fs.existsSync(CHANGELOG_PATH)) {
+    throw new Error('CHANGELOG.md is missing')
+  }
+
+  const unreleased = fs.readFileSync(UNRELEASED_PATH, 'utf8')
+  const notes = stripEmptySections(unreleased).trim()
+  const changelog = fs.readFileSync(CHANGELOG_PATH, 'utf8')
+
+  const heading = `## ${version} - ${date}`
+  const entry = notes ? `${heading}\n\n${notes}\n` : `${heading}\n`
+  const headingRe = new RegExp(`^## ${escapeRegExp(version)}(?: |$)`, 'm')
+  if (headingRe.test(changelog)) {
+    throw new Error(`CHANGELOG.md already has an entry for ${version}`)
+  }
+
+  const firstReleaseHeading = changelog.search(/^## /m)
+  if (firstReleaseHeading === -1) {
+    throw new Error('CHANGELOG.md has no release headings to insert before')
+  }
+
+  const updated = `${changelog.slice(0, firstReleaseHeading)}${entry}\n${changelog.slice(firstReleaseHeading)}`
+
+  fs.writeFileSync(CHANGELOG_PATH, updated)
+  fs.writeFileSync(UNRELEASED_PATH, UNRELEASED_TEMPLATE)
+  syncDocsChangelog(updated)
+
+  return { notes, empty: notes.length === 0 }
+}
+
+function syncDocsChangelog(changelogContents) {
+  const docsDir = path.dirname(DOCS_CHANGELOG_PATH)
+  if (!fs.existsSync(docsDir)) {
+    return
+  }
+  const docsChangelog = changelogContents.replaceAll('docs-website/docs/docs/', '').replaceAll('<', '&lt;')
+  fs.writeFileSync(DOCS_CHANGELOG_PATH, docsChangelog)
+}
+
+export function extractChangelog(version, changelogContents = fs.readFileSync(CHANGELOG_PATH, 'utf8')) {
+  const headingRe = new RegExp(`^## ${escapeRegExp(version)}(?: [-–].*)?$`, 'm')
+  const headingMatch = headingRe.exec(changelogContents)
+  if (!headingMatch) {
+    throw new Error(`No CHANGELOG.md entry found for ${version}`)
+  }
+
+  const start = headingMatch.index + headingMatch[0].length
+  const rest = changelogContents.slice(start)
+  const nextHeading = rest.search(/^## /m)
+  const body = (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).trim()
+  return body
+}
+
+function main(argv) {
+  const [command, version] = argv
+  if (!command || !version || !['roll', 'extract'].includes(command)) {
+    console.error('Usage: node scripts/prepare-changelog.mjs <roll|extract> <version>')
+    process.exit(1)
+  }
+
+  if (command === 'roll') {
+    const { notes, empty } = rollChangelog(version)
+    if (empty) {
+      console.log(`Rolled empty unreleased notes into ${version}`)
+    } else {
+      console.log(`Rolled unreleased notes into ${version} (${notes.split('\n').length} lines)`)
+    }
+    return
+  }
+
+  console.log(extractChangelog(version))
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isDirectRun) {
+  main(process.argv.slice(2))
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
+// Legacy interactive publisher. Prefer GitHub Actions:
+// Actions → Prepare Release → merge the PR → Publish Release runs automatically.
+// See .github/workflows/README.md
+//
 // inspired by `np` – https://github.com/sindresorhus/np
 
 import Listr from 'listr'


### PR DESCRIPTION
## Summary
- First NitromelonDB release: **0.30.0-alpha.0**, with `CHANGELOG-Unreleased.md` rolled into `CHANGELOG.md`.
- Adds the two-step GitHub Actions release flow (Prepare Release / Publish Release), including alpha/beta channels.
- npm publish is set up for **OIDC trusted publishing** (no `NPM_TOKEN`). This first version should be published from the CLI after merge so the package exists on npm; then attach a trusted publisher and later releases can go through CD.

## After merge (bootstrap npm)
```bash
git checkout master && git pull
yarn
yarn build
npm publish ./dist --access public --tag alpha --otp=<code>
```

Then on [nitromelondb access settings](https://www.npmjs.com/package/nitromelondb/access) add a GitHub Actions trusted publisher:
- Organization or user: `StasDoskalenko`
- Repository: `NitromelonDB`
- Workflow filename: `publish-release.yml`
- Environment: leave empty
- Allowed actions: `npm publish`

CD will not run on this merge (`publish-release.yml` is not on `master` yet). Later `release/v*` merges will.

## Test plan
- [ ] CI is green
- [ ] `package.json` version is `0.30.0-alpha.0`
- [ ] Changelog entry for 0.30.0-alpha.0 looks right; Unreleased file is reset
- [ ] After merge: local `yarn build && npm publish ./dist --tag alpha` succeeds
- [ ] After that publish: configure the trusted publisher on npmjs.com


Made with [Cursor](https://cursor.com)