### PR TITLE
Fix yarn build after android-jsi removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Contributors: Please add your changes to CHANGELOG-Unreleased.md
 - [Android] Added linker flag for building with 16kB page alignment
 - [Android] Generate `BuildConfig` under AGP 8+ (fixes `cannot find symbol: BuildConfig`)
 - [TS] make catchError visible to typescript
+- Stop copying the removed `native/android-jsi` tree in `yarn build` (package publish was failing with ENOENT)
+- Run `@babel/plugin-transform-typescript` before class-field plugins so `yarn build` can compile `declare` fields
 
 ### Changes
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -91,22 +91,33 @@ const envPlugins = (head = []) => ({
   },
 })
 
+const testPlugins = [...plugins, '@babel/plugin-syntax-jsx']
+
 // TypeScript must run before class-properties / decorators. Babel concatenates
 // override plugins after parent plugins, so TS files get a full plugin list here
 // instead of a parent config plus a trailing transform-typescript override.
-module.exports = {
-  overrides: [
-    {
-      test: /\.tsx$/,
-      env: envPlugins([typescriptPlugin(true)]),
-    },
-    {
-      test: /\.ts$/,
-      env: envPlugins([typescriptPlugin(false)]),
-    },
-    {
-      exclude: /\.tsx?$/,
-      env: envPlugins(),
-    },
-  ],
+// Export a function so Metro can attach `testPlugins` without Babel treating it
+// as an unknown config option.
+function babelConfig(api) {
+  api.cache(true)
+  return {
+    overrides: [
+      {
+        test: /\.tsx$/,
+        env: envPlugins([typescriptPlugin(true)]),
+      },
+      {
+        test: /\.ts$/,
+        env: envPlugins([typescriptPlugin(false)]),
+      },
+      {
+        exclude: /\.tsx?$/,
+        env: envPlugins(),
+      },
+    ],
+  }
 }
+
+babelConfig.testPlugins = testPlugins
+
+module.exports = babelConfig

--- a/babel.config.js
+++ b/babel.config.js
@@ -68,31 +68,45 @@ const plugins = [
   ],
 ]
 
-module.exports = {
-  env: {
-    development: {
-      plugins,
-    },
-    production: {
-      plugins: [
-        ...plugins,
-        'minify-flip-comparisons',
-        'minify-guarded-expressions',
-        'minify-dead-code-elimination',
-      ],
-    },
-    test: {
-      plugins: [...plugins, '@babel/plugin-syntax-jsx'],
-    },
+const minifyPlugins = [
+  'minify-flip-comparisons',
+  'minify-guarded-expressions',
+  'minify-dead-code-elimination',
+]
+
+const typescriptPlugin = (isTSX) => [
+  '@babel/plugin-transform-typescript',
+  { allowDeclareFields: true, isTSX },
+]
+
+const envPlugins = (head = []) => ({
+  development: {
+    plugins: [...head, ...plugins],
   },
+  production: {
+    plugins: [...head, ...plugins, ...minifyPlugins],
+  },
+  test: {
+    plugins: [...head, ...plugins, '@babel/plugin-syntax-jsx'],
+  },
+})
+
+// TypeScript must run before class-properties / decorators. Babel concatenates
+// override plugins after parent plugins, so TS files get a full plugin list here
+// instead of a parent config plus a trailing transform-typescript override.
+module.exports = {
   overrides: [
     {
       test: /\.tsx$/,
-      plugins: [['@babel/plugin-transform-typescript', { allowDeclareFields: true, isTSX: true }]],
+      env: envPlugins([typescriptPlugin(true)]),
     },
     {
       test: /\.ts$/,
-      plugins: [['@babel/plugin-transform-typescript', { allowDeclareFields: true }]],
+      env: envPlugins([typescriptPlugin(false)]),
+    },
+    {
+      exclude: /\.tsx?$/,
+      env: envPlugins(),
     },
   ],
 }

--- a/docs-website/docs/docs/CHANGELOG.md
+++ b/docs-website/docs/docs/CHANGELOG.md
@@ -31,6 +31,8 @@ Contributors: Please add your changes to CHANGELOG-Unreleased.md
 - [Android] Added linker flag for building with 16kB page alignment
 - [Android] Generate `BuildConfig` under AGP 8+ (fixes `cannot find symbol: BuildConfig`)
 - [TS] make catchError visible to typescript
+- Stop copying the removed `native/android-jsi` tree in `yarn build` (package publish was failing with ENOENT)
+- Run `@babel/plugin-transform-typescript` before class-field plugins so `yarn build` can compile `declare` fields
 
 ### Changes
 

--- a/native/metro-transformer.js
+++ b/native/metro-transformer.js
@@ -11,7 +11,7 @@ const isNodeModule = (filename) => {
 const isTypeScript = (filename) => /\.tsx?$/.test(filename) && !filename.endsWith('.d.ts')
 
 const pluginsForProjectFile = (filename) => {
-  const basePlugins = babelConfig.env.test.plugins
+  const basePlugins = babelConfig.testPlugins
   if (!isTypeScript(filename)) {
     return basePlugins
   }

--- a/scripts/make.mjs
+++ b/scripts/make.mjs
@@ -135,7 +135,6 @@ const copyNonJavaScriptFiles = (buildPath) => {
     'native/shared',
     'native/ios',
     'native/android',
-    'native/android-jsi',
     'native/nitro',
     'native/windows',
     'native/vendor/simdjson',
@@ -173,10 +172,6 @@ module.exports = {
   cleanFolder(`${buildPath}/native/ios/WatermelonDB.xcodeproj/xcuserdata`)
   cleanFolder(`${buildPath}/native/android/build`)
   cleanFolder(`${buildPath}/native/android/bin/build`)
-  cleanFolder(`${buildPath}/native/android-jsi/.cxx`)
-  cleanFolder(`${buildPath}/native/android-jsi/.externalNativeBuild`)
-  cleanFolder(`${buildPath}/native/android-jsi/build`)
-  cleanFolder(`${buildPath}/native/android-jsi/bin/build`)
   cleanFolder(`${buildPath}/native/windows/.vs`)
   cleanFolder(`${buildPath}/native/windows/x64`)
   cleanFolder(`${buildPath}/native/windows/WatermelonDB/Generated Files`)
@@ -216,7 +211,6 @@ if (isDevelopment) {
         resolvePath('native/ios/WatermelonDB'),
         resolvePath('native/shared'),
         resolvePath('native/android/src/main'),
-        resolvePath('native/android-jsi/src/main'),
         resolvePath('native/nitro'),
       ],
       {


### PR DESCRIPTION
## Summary
- Stop copying the removed `native/android-jsi` tree in `yarn build` (ENOENT on publish).
- Run `@babel/plugin-transform-typescript` before class-field plugins so `declare` fields compile in the production build.

These were blocking the local `0.30.0-alpha.0` publish. The tarball already went out with this build; this lands the same fixes on `master` so the next release does not regress.

## Test plan
- [ ] `yarn build` succeeds
- [ ] `dist/` has no `native/android-jsi`
- [ ] CI is green


Made with [Cursor](https://cursor.com)