### PR TITLE
Allow re-releasing alpha without a patch/minor/major bump

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ Automated releases for `nitromelondb`, modeled on the two-step process used in [
 
 | Field | Options | Purpose |
 | --- | --- | --- |
-| Version bump | `patch`, `minor`, `major` | Semver bump from the current `package.json` version |
+| Version bump | `none`, `patch`, `minor`, `major` | Semver bump. `none` keeps the current X.Y.Z (next `-alpha.N`, or graduate if prerelease is `none`) |
 | Prerelease | `none`, `alpha`, `beta` | Optional prerelease channel |
 
 **What it does:**
@@ -56,27 +56,18 @@ flowchart TD
 
 ## Versioning
 
-`package.json` is currently `0.28.1-0` (an unpublished prerelease of 0.28.1). Typical first releases:
+`package.json` is currently `0.30.0-alpha.0`. To ship another alpha of the same version, use bump **`none`** + prerelease **`alpha`**.
 
 | Current | Bump | Prerelease | Result |
 | --- | --- | --- | --- |
-| `0.28.1-0` | minor | alpha | `0.29.0-alpha.0` |
-| `0.28.1-0` | major | alpha | `1.0.0-alpha.0` |
-| `0.28.1-0` | minor | none | `0.29.0` |
-| `0.28.1-0` | patch | none | `0.28.1` |
-
-After that, repeating the same bump + channel increments the prerelease counter:
-
-| Current | Bump | Prerelease | Result |
-| --- | --- | --- | --- |
-| `0.29.0-alpha.0` | minor | alpha | `0.29.0-alpha.1` |
-| `0.29.0-alpha.1` | minor | beta | `0.29.0-beta.0` |
-| `0.29.0-beta.0` | minor | none | `0.29.0` |
-| `1.0.0-alpha.0` | major | alpha | `1.0.0-alpha.1` |
-| `1.0.0-alpha.2` | major | none | `1.0.0` |
+| `0.30.0-alpha.0` | none | alpha | `0.30.0-alpha.1` |
+| `0.30.0-alpha.1` | none | beta | `0.30.0-beta.0` |
+| `0.30.0-beta.0` | none | none | `0.30.0` |
+| `0.30.0-alpha.0` | major | alpha | `1.0.0-alpha.0` |
+| `0.28.1` | minor | alpha | `0.29.0-alpha.0` |
 | `0.28.1` | patch | none | `0.28.2` |
 
-Repeating the **same** bump + channel increments `-alpha.N` / `-beta.N`. Choosing `none` on an in-progress prerelease publishes that core version as stable. A *different* bump starts a new core version (`0.29.0-alpha.0` + major + alpha → `1.0.0-alpha.0`).
+`none` only works while a prerelease is in progress. Starting a new line still needs `patch` / `minor` / `major`. Repeating the **same** bump + channel also increments `-alpha.N` / `-beta.N`.
 
 npm dist-tags:
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,14 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       version_bump:
-        description: 'Version bump type'
+        description: 'Version bump (none = keep current X.Y.Z, next -alpha.N / graduate)'
         required: true
         type: choice
         options:
+          - none
           - patch
           - minor
           - major
-        default: 'patch'
+        default: 'none'
       prerelease:
         description: 'Prerelease channel (repeat alpha/beta increments -alpha.N / -beta.N)'
         required: true
@@ -20,7 +21,7 @@ on:
           - none
           - alpha
           - beta
-        default: 'none'
+        default: 'alpha'
 
 jobs:
   prepare:

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -13,3 +13,5 @@
 ### Changes
 
 ### Internal
+
+- Prepare Release accepts version bump `none` so another alpha/beta of the same X.Y.Z does not require picking patch/minor/major.

--- a/docs-website/docs/docs/Implementation/Publishing.md
+++ b/docs-website/docs/docs/Implementation/Publishing.md
@@ -13,10 +13,10 @@ Every merged change should already have a note there. Prepare Release copies tho
 1. GitHub → **Actions** → **Prepare Release**
 2. Run the workflow from **master**
 3. Choose:
-   - **Version bump:** `patch` / `minor` / `major`
+   - **Version bump:** `none` / `patch` / `minor` / `major` (`none` keeps the current X.Y.Z)
    - **Prerelease:** `none` / `alpha` / `beta`
 
-Repeat alpha/beta releases of the same version increment the counter (`0.29.0-alpha.0`, then `0.29.0-alpha.1`). Choosing `none` on an in-progress prerelease publishes that version as stable.
+To ship another alpha of the same version: bump **`none`** + prerelease **`alpha`** (`0.30.0-alpha.0` → `0.30.0-alpha.1`). Choosing prerelease `none` on an in-progress alpha/beta publishes that version as stable.
 
 ### Step 3: Review and merge the PR
 

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -5,19 +5,20 @@
  * Compute the next NitromelonDB version from a semver bump + optional prerelease channel.
  *
  * Usage:
- *   node scripts/next-version.mjs <patch|minor|major> <none|alpha|beta> [currentVersion]
+ *   node scripts/next-version.mjs <none|patch|minor|major> <none|alpha|beta> [currentVersion]
  *   node scripts/next-version.mjs --self-test
  *
  * Repeat alpha/beta releases of the same in-progress version increment the prerelease
  * counter (1.0.0-alpha.0 → 1.0.0-alpha.1). Switching channel resets it (alpha → beta.0).
- * Choosing `none` on a prerelease publishes that core version as stable.
+ * Choosing bump `none` keeps the current X.Y.Z (next -alpha.N, or graduate if prerelease is none).
+ * Choosing prerelease `none` on a prerelease publishes that core version as stable.
  */
 
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const BUMPS = new Set(['patch', 'minor', 'major'])
+const BUMPS = new Set(['none', 'patch', 'minor', 'major'])
 const PREIDS = new Set(['none', 'alpha', 'beta'])
 
 const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(?:\.(\d+))?|-(\d+))?$/
@@ -48,6 +49,8 @@ function formatCore({ major, minor, patch }) {
 
 function bumpCore(parsed, bump) {
   switch (bump) {
+    case 'none':
+      return { major: parsed.major, minor: parsed.minor, patch: parsed.patch }
     case 'major':
       return { major: parsed.major + 1, minor: 0, patch: 0 }
     case 'minor':
@@ -71,6 +74,9 @@ function bumpCore(parsed, bump) {
  *   1.0.0-alpha.0 + minor + alpha → 1.1.0-alpha.0
  */
 function shouldStayOnCurrentCore(parsed, bump) {
+  if (bump === 'none') {
+    return true
+  }
   if (bump === 'major') {
     return parsed.minor === 0 && parsed.patch === 0
   }
@@ -90,6 +96,12 @@ export function nextVersion(current, bump, preid) {
 
   const parsed = parseVersion(current)
   const currentCore = formatCore(parsed)
+
+  if (bump === 'none' && !parsed.hasPrerelease) {
+    throw new Error(
+      'Version bump "none" only works on an in-progress alpha/beta. Pick patch, minor, or major to start a new version.',
+    )
+  }
 
   let targetCore = currentCore
   if (!parsed.hasPrerelease) {
@@ -137,6 +149,12 @@ const SELF_TESTS = [
   ['1.0.0-alpha.0', 'minor', 'alpha', '1.1.0-alpha.0'],
   ['1.0.0-alpha.0', 'patch', 'alpha', '1.0.1-alpha.0'],
   ['0.29.0-alpha.0', 'patch', 'alpha', '0.29.1-alpha.0'],
+  ['0.30.0-alpha.0', 'none', 'alpha', '0.30.0-alpha.1'],
+  ['0.30.0-alpha.1', 'none', 'alpha', '0.30.0-alpha.2'],
+  ['0.30.0-alpha.1', 'none', 'beta', '0.30.0-beta.0'],
+  ['0.30.0-beta.0', 'none', 'none', '0.30.0'],
+  ['1.0.0-alpha.0', 'none', 'alpha', '1.0.0-alpha.1'],
+  ['1.0.0-alpha.2', 'none', 'none', '1.0.0'],
 ]
 
 function readCurrentVersion() {
@@ -156,11 +174,27 @@ function runSelfTest() {
       console.log(`ok    ${current} + ${bump} + ${preid} → ${actual}`)
     }
   }
+
+  const errorCases = [
+    ['0.30.0', 'none', 'alpha'],
+    ['0.30.0', 'none', 'none'],
+  ]
+  for (const [current, bump, preid] of errorCases) {
+    try {
+      const actual = nextVersion(current, bump, preid)
+      failed += 1
+      console.error(`FAIL  ${current} + ${bump} + ${preid} should throw, got ${actual}`)
+    } catch {
+      console.log(`ok    ${current} + ${bump} + ${preid} throws`)
+    }
+  }
+
+  const total = SELF_TESTS.length + errorCases.length
   if (failed) {
     console.error(`\n${failed} test(s) failed`)
     process.exit(1)
   }
-  console.log(`\n${SELF_TESTS.length} tests passed`)
+  console.log(`\n${total} tests passed`)
 }
 
 function main(argv) {
@@ -174,7 +208,7 @@ function main(argv) {
   const current = argv[2] || readCurrentVersion()
 
   if (!bump || !preid) {
-    console.error('Usage: node scripts/next-version.mjs <patch|minor|major> <none|alpha|beta> [currentVersion]')
+    console.error('Usage: node scripts/next-version.mjs <none|patch|minor|major> <none|alpha|beta> [currentVersion]')
     process.exit(1)
   }
 


### PR DESCRIPTION
## Summary
- Prepare Release version bump now includes **`none`**: keep the current X.Y.Z and only change the prerelease channel.
- `0.30.0-alpha.0` + none + alpha → `0.30.0-alpha.1`. none + none on an alpha graduates to stable `0.30.0`.
- `none` is rejected on an already-stable version so you cannot invent `0.30.0-alpha.0` after `0.30.0` is out.

Defaults are **none** + **alpha**, which is the next-alpha path from `0.30.0-alpha.0`.

## Test plan
- [ ] `node scripts/next-version.mjs --self-test`
- [ ] `node scripts/next-version.mjs none alpha` prints `0.30.0-alpha.1`
- [ ] Actions → Prepare Release shows `none` in the bump dropdown


Made with [Cursor](https://cursor.com)