### PR TITLE
Skip shipped versions when preparing a release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,12 +18,13 @@ Automated releases for `nitromelondb`, modeled on the two-step process used in [
 **What it does:**
 
 1. Calculates the next version (see [Versioning](#versioning))
-2. Creates a `release/vX.Y.Z` branch (or `release/vX.Y.Z-alpha.N` / `-beta.N`)
-3. Bumps `package.json`
-4. Moves `CHANGELOG-Unreleased.md` into `CHANGELOG.md` under the new version heading
-5. Resets `CHANGELOG-Unreleased.md` to empty section headers
-6. Syncs `docs-website/docs/docs/CHANGELOG.md`
-7. Opens a PR to `master` for review
+2. Skips versions that already have a git tag, GitHub Release, or npm publish (alpha/beta then increment `-alpha.N`)
+3. Creates or recreates a `release/vX.Y.Z` branch from master (leftover branches without a tag/release are reused; already-open PRs are not)
+4. Bumps `package.json`
+5. Moves `CHANGELOG-Unreleased.md` into `CHANGELOG.md` under the new version heading
+6. Resets `CHANGELOG-Unreleased.md` to empty section headers
+7. Syncs `docs-website/docs/docs/CHANGELOG.md`
+8. Opens a PR to `master` for review
 
 Run it from **master**: Actions → **Prepare Release** → Run workflow.
 
@@ -139,7 +140,9 @@ Do not add an `NPM_TOKEN` secret to this repository.
 
 ### PR not created
 - Check the Prepare Release run logs
-- Confirm `release/v…` does not already exist
+- If an open `release/v…` PR already exists, merge or close it first
+- A leftover `release/v…` branch with **no** git tag, GitHub Release, or npm version is recreated from master on retry
+- If that version already has a tag, GitHub Release, or npm publish, Prepare Release skips it and takes the next free version (for alpha, `0.30.0-alpha.1` → `0.30.0-alpha.2`)
 
 ### npm publish did not run
 - PR must come from `release/vX.Y.Z` (or `-alpha.N` / `-beta.N`) in this repository

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -57,9 +57,52 @@ jobs:
 
       - name: Calculate new version
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
+          version_taken_by() {
+            local ver="$1"
+            local tag="v${ver}"
+            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "git tag ${tag}"
+              return 0
+            fi
+            if gh release view "${tag}" >/dev/null 2>&1; then
+              echo "GitHub Release ${tag}"
+              return 0
+            fi
+            if npm view "nitromelondb@${ver}" version >/dev/null 2>&1; then
+              echo "npm nitromelondb@${ver}"
+              return 0
+            fi
+            return 1
+          }
+
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          NEW_VERSION=$(node scripts/next-version.mjs "${{ inputs.version_bump }}" "${{ inputs.prerelease }}" "$CURRENT_VERSION")
+          BUMP="${{ inputs.version_bump }}"
+          PREID="${{ inputs.prerelease }}"
+          NEW_VERSION=$(node scripts/next-version.mjs "$BUMP" "$PREID" "$CURRENT_VERSION")
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Bump: $BUMP / prerelease: $PREID"
+          echo "Candidate: $NEW_VERSION"
+
+          for _ in $(seq 1 50); do
+            if TAKEN_BY=$(version_taken_by "$NEW_VERSION"); then
+              echo "⚠️ v${NEW_VERSION} already exists (${TAKEN_BY}); computing the next version"
+              NEW_VERSION=$(node scripts/next-version.mjs "$BUMP" "$PREID" "$NEW_VERSION")
+              echo "Candidate: $NEW_VERSION"
+              continue
+            fi
+            break
+          done
+
+          if TAKEN_BY=$(version_taken_by "$NEW_VERSION"); then
+            echo "❌ Could not find a free version; last candidate v${NEW_VERSION} is still taken (${TAKEN_BY})"
+            exit 1
+          fi
 
           if [[ "$NEW_VERSION" == *-* ]]; then
             IS_PRERELEASE=true
@@ -72,21 +115,34 @@ jobs:
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
           echo "IS_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_ENV"
-
-          echo "Current version: $CURRENT_VERSION"
-          echo "Bump: ${{ inputs.version_bump }} / prerelease: ${{ inputs.prerelease }}"
           echo "✅ New version: $NEW_VERSION"
 
       - name: Create release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           BRANCH_NAME="release/v${{ env.NEW_VERSION }}"
-          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
-            echo "❌ Branch $BRANCH_NAME already exists on origin"
+
+          OPEN_PR=$(gh pr list --head "$BRANCH_NAME" --base master --state open --json url --jq '.[0].url // empty')
+          if [ -n "$OPEN_PR" ]; then
+            echo "❌ An open PR for $BRANCH_NAME already exists: $OPEN_PR"
             exit 1
           fi
-          git checkout -b "$BRANCH_NAME"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+            echo "⚠️ Branch $BRANCH_NAME exists but has no git tag, GitHub Release, or npm version."
+            echo "Treating it as a leftover from a failed run and recreating it from master."
+            git fetch origin "$BRANCH_NAME"
+            git checkout -B "$BRANCH_NAME" origin/master
+            echo "FORCE_PUSH=true" >> "$GITHUB_ENV"
+          else
+            git checkout -b "$BRANCH_NAME"
+            echo "FORCE_PUSH=false" >> "$GITHUB_ENV"
+          fi
+
           echo "PR_BRANCH=$BRANCH_NAME" >> "$GITHUB_ENV"
-          echo "✅ Branch created: $BRANCH_NAME"
+          echo "✅ Branch ready: $BRANCH_NAME"
 
       - name: Update package.json
         run: |
@@ -128,7 +184,11 @@ jobs:
             git add docs-website/package.json
           fi
           git commit -m "chore: release v${{ env.NEW_VERSION }}"
-          git push origin "${{ env.PR_BRANCH }}"
+          if [ "${{ env.FORCE_PUSH }}" = "true" ]; then
+            git push --force-with-lease origin "${{ env.PR_BRANCH }}"
+          else
+            git push origin "${{ env.PR_BRANCH }}"
+          fi
           echo "✅ Pushed ${{ env.PR_BRANCH }}"
 
       - name: Create Pull Request

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -15,3 +15,4 @@
 ### Internal
 
 - Prepare Release accepts version bump `none` so another alpha/beta of the same X.Y.Z does not require picking patch/minor/major.
+- Prepare Release skips versions that already have a git tag, GitHub Release, or npm publish, and only reuses a leftover `release/v…` branch when none of those exist.


### PR DESCRIPTION
## Summary
- A version is **taken** if a git tag, GitHub Release, or npm publish already exists. Prepare Release then computes the next free version (for alpha, `0.30.0-alpha.1` → `0.30.0-alpha.2`).
- A leftover `release/v*` branch is **not** treated as shipped. If there is no tag/release/npm version and no open PR, the branch is recreated from master so a retry after a permissions failure works.
- An already-open release PR still fails fast with its URL.

This is for the failed first Prepare Release of `0.30.0-alpha.1`, which pushed the branch but could not open the PR.

## Test plan
- [ ] After merge, re-run Prepare Release with none + alpha
- [ ] If `release/v0.30.0-alpha.1` still has no tag/release/npm version, it is reused (not skipped to alpha.2)
- [ ] If that version later has a tag or npm publish, the next run goes to alpha.2


Made with [Cursor](https://cursor.com)