### PR TITLE
Fix npm trusted publishing and set package author

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,15 +31,17 @@ Run it from **master**: Actions → **Prepare Release** → Run workflow.
 
 ### 2. `publish-release.yml` — Publish Release
 
-**Trigger:** Automatic when a `release/v*` PR is merged to `master`
+**Trigger:** Automatic when a `release/v*` PR is merged to `master`. Also manual (`workflow_dispatch` from **master`) to retry a version that is already on `master` but never made it to npm / git tag / GitHub Release.
 
 **What it does:**
 
 1. Builds the package (`yarn build` → `dist/`)
-2. Publishes `nitromelondb` to npm (`latest`, `alpha`, or `beta` dist-tag)
+2. Publishes `nitromelondb` to npm (`latest`, `alpha`, or `beta` dist-tag) via OIDC trusted publishing
 3. Creates git tag `vX.Y.Z`
 4. Creates a GitHub Release (marked as prerelease for alpha/beta)
-5. Comments on the PR with npm and GitHub links
+5. Comments on the PR with npm and GitHub links (merge trigger only)
+
+Do **not** set `registry-url` on `actions/setup-node` in this workflow. That writes `_authToken=${NODE_AUTH_TOKEN}` into `.npmrc` and npm then skips OIDC (`E404` / `ENEEDAUTH`).
 
 ## Release process
 
@@ -157,4 +159,8 @@ Do not add an `NPM_TOKEN` secret to this repository.
 - Confirm the workflow has `id-token: write` (it does in `publish-release.yml`)
 - Confirm that version is not already on npm
 - Review the Publish Release logs
-- `ENEEDAUTH` almost always means the workflow filename or repo name does not match the trusted publisher config (case-sensitive, include `.yml`)
+- `ENEEDAUTH` or `E404` on `PUT https://registry.npmjs.org/nitromelondb` usually means npm never did the OIDC exchange. Typical cause: `actions/setup-node` `registry-url` wrote an empty `_authToken` into `.npmrc`. Re-run after that is removed; do not add an `NPM_TOKEN` secret.
+- `ENEEDAUTH` can also mean the workflow filename or repo name does not match the trusted publisher config (case-sensitive, include `.yml`)
+
+### Retry a failed publish (no new version)
+Do **not** run Prepare Release again — that would bump to the next `-alpha.N` / `-beta.N`. After the fix is on `master`: Actions → **Publish Release** → Run workflow (branch **master**). That publishes the version already in `package.json`, then creates the git tag and GitHub Release if they are missing.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,7 +41,7 @@ Run it from **master**: Actions → **Prepare Release** → Run workflow.
 4. Creates a GitHub Release (marked as prerelease for alpha/beta)
 5. Comments on the PR with npm and GitHub links (merge trigger only)
 
-Do **not** set `registry-url` on `actions/setup-node` in this workflow. That writes `_authToken=${NODE_AUTH_TOKEN}` into `.npmrc` and npm then skips OIDC (`E404` / `ENEEDAUTH`).
+OIDC publish uses `actions/setup-node@v6` + Node 24 (npm ≥ 11.5.1). Do **not** set `registry-url` (it writes `_authToken` and npm skips OIDC). The publish step runs `NODE_AUTH_TOKEN="" npm publish ./dist … --verbose` so a leftover dummy token cannot mask trusted publishing. Provenance is generated automatically on OIDC publishes from this public repo.
 
 ## Release process
 
@@ -159,7 +159,7 @@ Do not add an `NPM_TOKEN` secret to this repository.
 - Confirm the workflow has `id-token: write` (it does in `publish-release.yml`)
 - Confirm that version is not already on npm
 - Review the Publish Release logs
-- `ENEEDAUTH` or `E404` on `PUT https://registry.npmjs.org/nitromelondb` usually means npm never did the OIDC exchange. Typical cause: `actions/setup-node` `registry-url` wrote an empty `_authToken` into `.npmrc`. Re-run after that is removed; do not add an `NPM_TOKEN` secret.
+- `ENEEDAUTH` or `E404` on `PUT https://registry.npmjs.org/nitromelondb` usually means npm never did the OIDC exchange. Typical cause: `actions/setup-node` `registry-url` wrote `_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`, or a dummy `NODE_AUTH_TOKEN`. Use Node 24 / setup-node v6, no `registry-url`, and `NODE_AUTH_TOKEN=""` on `npm publish`. Do not add an `NPM_TOKEN` secret.
 - `ENEEDAUTH` can also mean the workflow filename or repo name does not match the trusted publisher config (case-sensitive, include `.yml`)
 
 ### Retry a failed publish (no new version)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -95,12 +95,6 @@ jobs:
             echo "See the changelog for details." > /tmp/release_notes.md
           fi
 
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: 'node_modules'
-          key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
-
       - name: Install dependencies
         run: yarn
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
     branches:
       - master
+  workflow_dispatch:
 
 concurrency:
   group: publish-release
@@ -13,16 +14,28 @@ concurrency:
 jobs:
   publish:
     if: |
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'release/v')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'release/v')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       id-token: write
     steps:
+      - name: Ensure workflow ran from master
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/master" ]; then
+            echo "❌ Run Publish Release from the master branch (selected: ${{ github.ref_name }})"
+            exit 1
+          fi
+
       - name: Validate release branch
+        if: github.event_name == 'pull_request_target'
         run: |
           BRANCH="${{ github.event.pull_request.head.ref }}"
           if [[ ! "$BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
@@ -34,14 +47,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Set Node.js version
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-          registry-url: 'https://registry.npmjs.org'
+          # Do not set registry-url. It writes `_authToken=${NODE_AUTH_TOKEN}` into
+          # .npmrc, which makes npm skip OIDC trusted publishing (E404 / ENEEDAUTH).
 
       - name: Ensure npm supports OIDC trusted publishing
         run: npm install -g npm@latest
@@ -98,6 +112,10 @@ jobs:
       - name: Publish to npm
         run: |
           unset NODE_AUTH_TOKEN
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+            sed -i '/always-auth/d' "$NPM_CONFIG_USERCONFIG"
+          fi
           if npm view "nitromelondb@${{ env.NEW_VERSION }}" version >/dev/null 2>&1; then
             echo "nitromelondb@${{ env.NEW_VERSION }} is already on npm, skipping publish"
           else
@@ -133,6 +151,7 @@ jobs:
           fi
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request_target'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
+      id-token: write # Required for npm OIDC trusted publishing
     steps:
       - name: Ensure workflow ran from master
         if: github.event_name == 'workflow_dispatch'
@@ -45,20 +45,18 @@ jobs:
           echo "✅ Valid release branch: $BRANCH"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 24.x
-          # Do not set registry-url. It writes `_authToken=${NODE_AUTH_TOKEN}` into
-          # .npmrc, which makes npm skip OIDC trusted publishing (E404 / ENEEDAUTH).
-
-      - name: Ensure npm supports OIDC trusted publishing
-        run: npm install -g npm@latest
+          node-version: '24'
+          # Do not set registry-url: it writes `_authToken=${NODE_AUTH_TOKEN}` and
+          # npm then skips OIDC. Node 24 ships npm >= 11.5.1 (required for OIDC).
+          package-manager-cache: false
 
       - name: Configure Git
         run: |
@@ -111,15 +109,10 @@ jobs:
 
       - name: Publish to npm
         run: |
-          unset NODE_AUTH_TOKEN
-          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
-            sed -i '/always-auth/d' "$NPM_CONFIG_USERCONFIG"
-          fi
           if npm view "nitromelondb@${{ env.NEW_VERSION }}" version >/dev/null 2>&1; then
             echo "nitromelondb@${{ env.NEW_VERSION }} is already on npm, skipping publish"
           else
-            npm publish ./dist --access public --tag "${{ env.DIST_TAG }}"
+            NODE_AUTH_TOKEN="" npm publish ./dist --access public --tag "${{ env.DIST_TAG }}" --verbose
             echo "✅ Published nitromelondb@${{ env.NEW_VERSION }} with tag ${{ env.DIST_TAG }}"
           fi
 

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -16,5 +16,5 @@
 
 - Prepare Release skips versions that already have a git tag, GitHub Release, or npm publish, and only reuses a leftover `release/v…` branch when none of those exist.
 - Prepare Release folds all same-version alpha/beta changelog entries into one official entry when graduating to a stable release.
-- Publish Release uses npm OIDC without `setup-node` `registry-url`, so trusted publishing is not blocked by an empty `_authToken`. Failed publishes can be retried from Actions → Publish Release.
+- Publish Release uses `setup-node@v6` + Node 24 OIDC (`NODE_AUTH_TOKEN=""` on `npm publish`, no `registry-url`). Failed publishes can be retried from Actions → Publish Release.
 - Package `author` is Stanislav Doskalenko.

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -16,3 +16,5 @@
 
 - Prepare Release skips versions that already have a git tag, GitHub Release, or npm publish, and only reuses a leftover `release/v…` branch when none of those exist.
 - Prepare Release folds all same-version alpha/beta changelog entries into one official entry when graduating to a stable release.
+- Publish Release uses npm OIDC without `setup-node` `registry-url`, so trusted publishing is not blocked by an empty `_authToken`. Failed publishes can be retried from Actions → Publish Release.
+- Package `author` is Stanislav Doskalenko.

--- a/docs-website/docs/docs/Implementation/Publishing.md
+++ b/docs-website/docs/docs/Implementation/Publishing.md
@@ -30,6 +30,8 @@ Merging the PR:
 - Publishes `nitromelondb` to npm (`latest`, `alpha`, or `beta`)
 - Creates the git tag and GitHub Release
 
+If npm publish fails, do not run Prepare Release again. After the fix is on `master`, run **Actions → Publish Release** from **master** to retry the same version.
+
 ### Local helpers
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "vendor:sqlite": "node ./scripts/vendor-sqlite.mjs"
   },
   "types": "src/index.ts",
-  "author": "@Nozbe",
+  "author": {
+    "name": "Stanislav Doskalenko",
+    "url": "https://github.com/StasDoskalenko"
+  },
   "homepage": "https://stasdoskalenko.github.io/NitromelonDB/",
   "bugs": "https://github.com/StasDoskalenko/NitromelonDB/issues",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Publish of `0.30.0-alpha.1` failed with `E404 PUT https://registry.npmjs.org/nitromelondb` because `actions/setup-node` `registry-url` wrote `_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`, so npm skipped OIDC trusted publishing.
- Remove `registry-url`, strip leftover auth lines, and add **Actions → Publish Release** (`workflow_dispatch` from master) so we can retry the same version without bumping to alpha.2.
- Set package `author` to Stanislav Doskalenko.

## Test plan
- [ ] Merge this PR to `master` first (the new Publish Release trigger is only available after that).
- [ ] Confirm trusted publisher on npmjs.com is `StasDoskalenko` / `NitromelonDB` / `publish-release.yml`.
- [ ] Actions → **Publish Release** → Run workflow from **master** (do **not** run Prepare Release again).
- [ ] Confirm `nitromelondb@0.30.0-alpha.1` on npm (`alpha` dist-tag), git tag `v0.30.0-alpha.1`, and a GitHub prerelease.


Made with [Cursor](https://cursor.com)