### PR TITLE
Stop setup-node from skipping npm OIDC

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,7 +41,9 @@ Run it from **master**: Actions → **Prepare Release** → Run workflow.
 4. Creates a GitHub Release (marked as prerelease for alpha/beta)
 5. Comments on the PR with npm and GitHub links (merge trigger only)
 
-OIDC publish follows the [npm trusted publishers GitHub Actions example](https://docs.npmjs.com/trusted-publishers#github-actions-configuration): `actions/checkout@v6`, `actions/setup-node@v6`, Node 24, `registry-url: https://registry.npmjs.org`, `package-manager-cache: false`, and `id-token: write`. We still `yarn build` and `npm publish ./dist` (this repo publishes the built tree, not the source root). Provenance is generated automatically on OIDC publishes from this public repo.
+OIDC publish uses `actions/checkout@v6`, `actions/setup-node@v6`, Node 24, `package-manager-cache: false`, and `id-token: write`. We `yarn build` then `npm publish ./dist`.
+
+**Do not set `registry-url` on `setup-node`.** The [npm trusted publishers example](https://docs.npmjs.com/trusted-publishers#github-actions-configuration) includes it, but `setup-node` then writes `_authToken=${NODE_AUTH_TOKEN}` and a dummy `NODE_AUTH_TOKEN`. npm treats that as classic auth, skips OIDC, and fails with `PUT … 404 Not Found` even though `nitromelondb` exists. The publish step also `unset NODE_AUTH_TOKEN` and strips leftover `_authToken` lines. Provenance is generated automatically on OIDC publishes from this public repo.
 
 We do **not** use `on: push: tags: v*` as the primary trigger. This workflow creates the git tag with `GITHUB_TOKEN` after a release PR merge; events from `GITHUB_TOKEN` do not start a second workflow, so a tag-only job would never run. Merge + **Actions → Publish Release** (retry) is the equivalent.
 
@@ -127,7 +129,7 @@ Then:
 
 1. Open [nitromelondb access settings](https://www.npmjs.com/package/nitromelondb/access)
 2. Under **Trusted Publisher**, choose **GitHub Actions**
-3. Fill in exactly:
+3. Fill in **exactly** (case-sensitive; these are GitHub names, **not** the npm package `nitromelondb`):
 
    | Field | Value |
    | --- | --- |
@@ -161,8 +163,8 @@ Do not add an `NPM_TOKEN` secret to this repository.
 - Confirm the workflow has `id-token: write` (it does in `publish-release.yml`)
 - Confirm that version is not already on npm
 - Review the Publish Release logs
-- `ENEEDAUTH` or `OIDC token exchange error - package not found` usually means the Trusted Publisher on npmjs.com is missing or does not match this workflow. Use `StasDoskalenko` / `NitromelonDB` / `publish-release.yml`, leave Environment empty, allow `npm publish`, and click **Save**.
-- `ENEEDAUTH` can also mean the workflow filename or repo name does not match (case-sensitive, include `.yml`)
+- `PUT https://registry.npmjs.org/nitromelondb` **404** with **no** `/-/npm/v1/oidc/token/exchange` line means npm skipped OIDC (dummy `NODE_AUTH_TOKEN` from `setup-node` `registry-url`). This workflow must not set `registry-url`.
+- `ENEEDAUTH` or `OIDC token exchange error - package not found` means OIDC ran but Trusted Publisher does not match GitHub's casing: `StasDoskalenko` / `NitromelonDB` / `publish-release.yml` (not the lowercase npm name `nitromelondb`). Environment empty, allow `npm publish`, then **Save**.
 
 ### Retry a failed publish (no new version)
 Do **not** run Prepare Release again — that would bump to the next `-alpha.N` / `-beta.N`. After the fix is on `master`: Actions → **Publish Release** → Run workflow (branch **master**). That publishes the version already in `package.json`, then creates the git tag and GitHub Release if they are missing.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,7 +54,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          # Do not set registry-url. setup-node then writes
+          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and a dummy
+          # NODE_AUTH_TOKEN, and npm skips OIDC (PUT 404 / ENEEDAUTH).
           package-manager-cache: false
 
       - name: Configure Git
@@ -102,10 +104,19 @@ jobs:
 
       - name: Publish to npm
         run: |
+          unset NODE_AUTH_TOKEN
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+            sed -i '/always-auth/d' "$NPM_CONFIG_USERCONFIG"
+          fi
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL is unset; id-token: write did not take effect"
+            exit 1
+          fi
           if npm view "nitromelondb@${{ env.NEW_VERSION }}" version >/dev/null 2>&1; then
             echo "nitromelondb@${{ env.NEW_VERSION }} is already on npm, skipping publish"
           else
-            npm publish ./dist --access public --tag "${{ env.DIST_TAG }}"
+            npm publish ./dist --access public --tag "${{ env.DIST_TAG }}" --verbose
             echo "✅ Published nitromelondb@${{ env.NEW_VERSION }} with tag ${{ env.DIST_TAG }}"
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Contributors: Please add your changes to CHANGELOG-Unreleased.md
 
 ## 0.30.0-alpha.3 - 2026-08-15
 
+### Internal
+
+- Publish Release omits `setup-node` `registry-url` so npm uses OIDC instead of a dummy `NODE_AUTH_TOKEN` (which caused `PUT 404` for a package that already exists).
+
 ## 0.30.0-alpha.2 - 2026-08-15
 
 ### Fixes

--- a/docs-website/docs/docs/CHANGELOG.md
+++ b/docs-website/docs/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ Contributors: Please add your changes to CHANGELOG-Unreleased.md
 
 ## 0.30.0-alpha.3 - 2026-08-15
 
+### Internal
+
+- Publish Release omits `setup-node` `registry-url` so npm uses OIDC instead of a dummy `NODE_AUTH_TOKEN` (which caused `PUT 404` for a package that already exists).
+
 ## 0.30.0-alpha.2 - 2026-08-15
 
 ### Fixes


### PR DESCRIPTION
## Summary
- The alpha.3 publish log shows `NODE_AUTH_TOKEN: XXXXX-…` and `NPM_CONFIG_USERCONFIG: …/.npmrc`, then `PUT https://registry.npmjs.org/nitromelondb` **404** with **no** OIDC token-exchange request. The package already exists (`0.30.0-alpha.0`).
- That is `actions/setup-node` `registry-url` (from the npm docs example) writing `_authToken=${NODE_AUTH_TOKEN}` so npm never uses Trusted Publisher.
- Remove `registry-url`, `unset NODE_AUTH_TOKEN`, strip leftover `_authToken` lines, and publish with `--verbose`.

## Test plan
- [ ] Merge this PR. **Do not run Prepare Release** (that would bump to alpha.4).
- [ ] Actions → **Publish Release** → Run workflow from **master**.
- [ ] Logs should show `…/idtoken… audience=npm:registry.npmjs.org` then `…/oidc/token/exchange/package/nitromelondb`.
- [ ] Confirm `nitromelondb@0.30.0-alpha.3` on npm.


Made with [Cursor](https://cursor.com)