### PR TITLE
fix: ship working npm types and close WatermelonDB migration gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn test:metro-transform
+      - run: node scripts/published-package.mjs --self-test
       - run: node scripts/next-version.mjs --self-test
       - run: node scripts/prepare-changelog.mjs --self-test
       - name: Gradle Wrapper Validation

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -1,5 +1,7 @@
 ### Highlights
 
+- Published package types, `exports`, `rxjs` peer, and Nitro peer range so a WatermelonDB → NitromelonDB swap does not need `tsconfig` path hacks.
+
 ### BREAKING CHANGES
 
 ### Deprecations
@@ -10,12 +12,21 @@
 
 ### Fixes
 
+- **npm types:** the published `package.json` now points `types` at `index.d.ts`. Ramda `merge` was leaving `"types": "src/index.ts"`, which is not in the tarball.
+- **`@json` sanitizers:** `json<T>()` accepts typed sanitizers again (`(source: T) => T`). `memo` on the options object is optional.
+- **`Model.id`:** assigning `record.id = 'custom'` inside `create()` / `prepareCreate()` works. It throws after create instead of silently no-op'ing.
+
 ### Performance
 
 ### Changes
 
 - Docs site version badge tracks the npm package (including alpha/beta). It had stayed on `0.28.0` through the `0.30.0` prereleases.
 - README and docs use the Nitromelon icon, link to full documentation right after the intro, and credit the original WatermelonDB.
+- `rxjs` is a peer dependency (`^7.8.0`) as well as a dependency, so Yarn can hoist the host copy.
+- `react-native-nitro-modules` peer range is `>=0.35.2` (was `*`).
+- Published package includes an `exports` map for `nitromelondb`, `nitromelondb/decorators`, `nitromelondb/adapters/sqlite`, and other directory imports.
+- Migration guide: do not retarget `native/android-jsi` or iOS `SupportingFiles` paths; Jest/Metro mocks; Expo plugin is optional on bare RN; New Architecture required, tested on RN 0.83+.
+- `RelationId` is exported from the package root.
 
 ### Internal
 

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -15,6 +15,7 @@
 - **npm types:** the published `package.json` now points `types` at `index.d.ts`. Ramda `merge` was leaving `"types": "src/index.ts"`, which is not in the tarball.
 - **`@json` sanitizers:** `json<T>()` accepts typed sanitizers again (`(source: T) => T`). `memo` on the options object is optional.
 - **`Model.id`:** assigning `record.id = 'custom'` inside `create()` / `prepareCreate()` works. It throws after create instead of silently no-op'ing.
+- **Metro / `nitro.json`:** native `require('.../nitro')` resolved to package-root `nitro.json` instead of `nitro/index.js`, so the HybridObject never loaded in release bundles. Requires now use `.../nitro/index`.
 
 ### Performance
 

--- a/docs-website/docs/docs/Advanced/AdvancedFields.md
+++ b/docs-website/docs/docs/Advanced/AdvancedFields.md
@@ -38,7 +38,9 @@ comment.update(() => {
 
 As the second argument, pass a **sanitizer function**. This is a function that receives whatever `JSON.parse()` returns for the serialized JSON, and returns whatever type you expect in your app. In other words, it turns raw, dirty, untrusted data (that might be missing, or malformed by a bug in previous version of the app) into trusted format.
 
-The sanitizer might also receive `null` if the column is nullable, or `undefined` if the field doesn't contain valid JSON.
+`json()` is generic (`json<T>(column, (source: T) => T)`), so a sanitizer typed as `(source: ContactInfo) => ContactInfo` type-checks. The sanitizer might also receive `null` if the column is nullable, or `undefined` if the field doesn't contain valid JSON.
+
+Pass `{ memo: true }` as a third argument to reuse the last sanitized value when the raw column has not changed. `memo` is optional and defaults to `false`.
 
 For example, if you need the field to be an array of strings, you can ensure it like so:
 

--- a/docs-website/docs/docs/Advanced/Flow.md
+++ b/docs-website/docs/docs/Advanced/Flow.md
@@ -5,8 +5,15 @@ hide_title: true
 
 # Flow support removed
 
-WatermelonDB's JavaScript source is TypeScript. Flow types, `.flowconfig`, and `flow-bin` are no longer shipped.
+WatermelonDB's JavaScript source is TypeScript. Flow types, `.flowconfig`, `flow-bin`, and `@nozbe/watermelondb/types` are no longer shipped.
 
 Use [TypeScript](https://www.typescriptlang.org/) instead. See the [TypeScript example](https://github.com/StasDoskalenko/NitromelonDB/tree/master/examples/typescript) for model, schema, and query typing.
+
+| Flow | TypeScript |
+| --- | --- |
+| `RecordId` | `import type { RecordId } from 'nitromelondb'` |
+| `TableName<T>`, `ColumnName` | `import type { TableName, ColumnName } from 'nitromelondb'` |
+| `$Call<…>` relation id extractors | `import type { RelationId } from 'nitromelondb'` |
+| `$Diff`, `$Rest`, `$Shape` | `Omit`, `Partial`, `Pick` |
 
 If you are switching from `@nozbe/watermelondb`, see [Migrating from WatermelonDB](../Migrating.md).

--- a/docs-website/docs/docs/CRUD.md
+++ b/docs-website/docs/docs/CRUD.md
@@ -114,12 +114,13 @@ await somePost.destroyPermanently() // permanent
 - `Collection.findAndObserve(id)` — same as using `.find(id)` and then calling `record.observe()`
 - `Model.prepareUpdate()`, `Collection.prepareCreate`, `Database.batch` — used for [batch updates](./Writers.md)
 - `Database.unsafeResetDatabase()` destroys the whole database - [be sure to see this comment before using it](https://github.com/Nozbe/WatermelonDB/blob/22188ee5b6e3af08e48e8af52d14e0d90db72925/src/Database/index.js#L131)
-- To override the `record.id` during the creation, e.g. to sync with a remote database, you can do it by `record._raw` property. Be aware that the `id` must be of type `string`.
+- To override the `record.id` during creation (for example to match a server id), assign `record.id` inside `create()` / `prepareCreate()`. The id must be a non-empty string. Assigning `id` after create throws.
     ```js
     await database.get('posts').create(post => {
-      post._raw.id = serverId
+      post.id = serverId
     })
     ```
+    `post._raw.id = serverId` and `collection.prepareCreateFromDirtyRaw({ id: serverId, ... })` still work.
 
 ### Advanced: Unsafe raw execute
 

--- a/docs-website/docs/docs/Installation.mdx
+++ b/docs-website/docs/docs/Installation.mdx
@@ -18,14 +18,16 @@ npm install nitromelondb
 Native SQLite on iOS and Android uses [Nitro Modules](https://nitro.margelo.com) and React Native **autolinking** (`react-native.config.js` + the `NitromelonDB` podspec). `simdjson` is compiled into that pod from vendored sources. You do not add CocoaPods or Gradle lines by hand, and you do not run a separate setup CLI. Expo is fully supported — development builds, EAS Build, and EAS Update. See [Expo](#expo).
 
 :::warning New Architecture only
-NitromelonDB does **not** support the old React Native architecture (Paper / the legacy bridge). Enable the New Architecture. React Native 0.87 has it on by default.
+NitromelonDB does **not** support the old React Native architecture (Paper / the legacy bridge). Enable the New Architecture. Tested on React Native **0.83+**. React Native 0.87 has it on by default.
 :::
 
 ```bash
-yarn add nitromelondb react-native-nitro-modules
+yarn add nitromelondb rxjs@^7.8.0
+# skip if the app already depends on it:
+yarn add react-native-nitro-modules
 ```
 
-`react-native-nitro-modules` is required for SQLite on iOS and Android. It is optional on web / Node / Electron.
+`rxjs` `^7.8.0` is a peer dependency. `react-native-nitro-modules` `>=0.35.2` is required for SQLite on iOS and Android. It is optional on web / Node / Electron. Do not add `react-native-nitro-modules` a second time if it is already in the app.
 
 1. Install the Babel plugin for decorators if you haven't already:
 
@@ -46,7 +48,7 @@ yarn add nitromelondb react-native-nitro-modules
 
 3. Rebuild the native app after adding these packages. Autolinking runs as part of the usual Expo / React Native CLI flow (`use_native_modules!` on iOS). There is no extra setup command.
 
-Minimums: Xcode 15+, iOS 15.1, Android minSdk 24, React Native **New Architecture**. This will not run in Expo Go.
+Minimums: Xcode 15+, iOS 15.1, Android minSdk 24, React Native **0.83+ with New Architecture**. This will not run in Expo Go.
 
 ## Expo
 
@@ -70,7 +72,7 @@ NitromelonDB fully supports Expo **development builds**, **EAS Build**, and **EA
    }
    ```
 
-   The plugin runs during `expo prebuild` (EAS Build does this for you). It does **not** install the old `watermelondb-jsi` Android module — SQLite goes through Nitro autolinking. It rejects `"newArchEnabled": false`.
+   The plugin is optional for **bare** React Native — autolinking is what actually links SQLite. On Expo it runs during `expo prebuild` (EAS Build does this for you). It does **not** install the old `watermelondb-jsi` Android module. It rejects `"newArchEnabled": false`.
 
    Optional:
 
@@ -123,7 +125,7 @@ npx react-native run-android
 
 `run-ios` installs pods and applies autolinking. You do not add `pod 'NitromelonDB'` or `pod 'simdjson'` to the Podfile.
 
-We highly recommend that you _do not_ use `use_frameworks!`. If NitromelonDB fails to build in frameworks mode, [use this workaround](https://github.com/Nozbe/WatermelonDB/issues/1285#issuecomment-1381323060) to force static libraries. Manual (non-CocoaPods) iOS linking is not supported.
+We highly recommend that you _do not_ use `use_frameworks!`. If you need it (RN Firebase often uses `use_frameworks! :linkage => :static`), prefer **static** linkage. If NitromelonDB fails to build in frameworks mode, [use this workaround](https://github.com/Nozbe/WatermelonDB/issues/1285#issuecomment-1381323060) to force static libraries. Manual (non-CocoaPods) iOS linking is not supported.
 
 ### Android (React Native)
 

--- a/docs-website/docs/docs/Migrating.md
+++ b/docs-website/docs/docs/Migrating.md
@@ -221,6 +221,7 @@ Assigning `record.id` anywhere else throws. `_raw.id` and `prepareCreateFromDirt
 - Move `__mocks__/@nozbe/watermelondb` to `__mocks__/nitromelondb` (and the same for any subpath mocks).
 - Do **not** path-map `nitromelondb` to unpublished `.ts` sources or to a `.d.ts` file. The published package is compiled JS at the package root.
 - That compiled JS does **not** need `transformIgnorePatterns` for `nitromelondb`.
+- If a release bundle loads `nitro.json` and SQLite never opens, you are on `0.30.0-beta.1`. Upgrade; do not patch `require('.../nitro')` yourself after that.
 
 ## 9. Platform floor
 

--- a/docs-website/docs/docs/Migrating.md
+++ b/docs-website/docs/docs/Migrating.md
@@ -17,24 +17,30 @@ Your existing SQLite files, schema version, migrations, and model classes keep w
 
 ```bash
 yarn remove @nozbe/watermelondb
-yarn add nitromelondb
+yarn add nitromelondb rxjs@^7.8.0
 
 # (or with npm:)
 npm uninstall @nozbe/watermelondb
-npm install nitromelondb
+npm install nitromelondb rxjs@^7.8.0
 ```
 
-On React Native (iOS and Android), also add the Nitro peer and rebuild native code:
+`rxjs` is a **peer dependency** (`^7.8.0`). Most apps already have it. Aligning the range avoids Yarn nesting a second copy (which breaks `Observable` / `Subscription` types).
+
+On React Native (iOS and Android), also add the Nitro peer and rebuild native code — **skip this if `react-native-nitro-modules` is already in the app** (do not double-install it):
 
 ```bash
 yarn add react-native-nitro-modules
 ```
 
+Use `react-native-nitro-modules` **0.35.2 or newer**. NitromelonDB is built against 0.36.x; a `*` peer range used to hide ABI mismatches that only show up in Xcode or Gradle.
+
 `react-native-nitro-modules` is optional for web / Node / Electron. It is **required** for SQLite on iOS and Android.
+
+After the JS swap you still need **`pod install` and a full native rebuild**. Metro reload is not enough.
 
 ## 2. Rewrite imports
 
-Replace the old scope everywhere — `package.json`, source, tests, Metro/tsconfig path aliases:
+Replace the old scope in **JavaScript/TypeScript source, tests, and Jest mocks** — not in leftover native project files (see [iOS](#3-ios) and [Android](#4-android)):
 
 | From | To |
 | --- | --- |
@@ -45,8 +51,10 @@ Replace the old scope everywhere — `package.json`, source, tests, Metro/tsconf
 | `@nozbe/watermelondb/react` | `nitromelondb/react` |
 | `@nozbe/watermelondb/sync` | `nitromelondb/sync` |
 | `@nozbe/watermelondb/Schema/migrations` | `nitromelondb/Schema/migrations` |
+| `@nozbe/watermelondb/utils/common/randomId` | `nitromelondb/utils/common/randomId` |
+| `@nozbe/watermelondb/utils/common/logger` | `nitromelondb/utils/common/logger` |
 
-A project-wide replace of `@nozbe/watermelondb` → `nitromelondb` is enough for imports.
+A project-wide replace of `@nozbe/watermelondb` → `nitromelondb` is enough for **JS/TS imports**. It is **not** enough for native files.
 
 Leave **other** `@nozbe/*` packages alone. `simdjson` and SQLite are vendored inside NitromelonDB (`native/vendor/`).
 
@@ -66,13 +74,6 @@ import { withObservables } from 'nitromelondb/react'
 import { synchronize } from 'nitromelondb/sync'
 ```
 
-Also update `node_modules` paths if you still have any (Windows native projects, old manual Gradle):
-
-| From | To |
-| --- | --- |
-| `node_modules/@nozbe/watermelondb` | `node_modules/nitromelondb` |
-| `node_modules\@nozbe\watermelondb` (Windows) | `node_modules\nitromelondb` |
-
 ## 3. iOS
 
 Autolinking picks up the `NitromelonDB` pod. **Remove** any WatermelonDB / simdjson / FMDB lines you added by hand — simdjson is compiled into NitromelonDB from vendored sources. You do not add a `pod 'simdjson'`, `pod 'FMDB'`, or `pod 'NitromelonDB'` line. FMDB is not used.
@@ -86,6 +87,8 @@ pod 'simdjson', path: '../node_modules/@nozbe/simdjson', modular_headers: true
 
 Then `pod install` (Expo: `npx expo prebuild`).
 
+`use_frameworks! :linkage => :static` (common in RN Firebase apps) is supported. Prefer static linkage if you must use frameworks. See [Installation — Bare React Native](./Installation.mdx#bare-react-native).
+
 **Bridging header** (only if you import the native header yourself):
 
 ```objc
@@ -96,25 +99,32 @@ Then `pod install` (Expo: `npx expo prebuild`).
 #import <NitromelonDB/WatermelonDB.h>
 ```
 
+:::warning Do not retarget old header search paths
+A project-wide path replace will turn `node_modules/@nozbe/watermelondb/native/ios/.../SupportingFiles` into `node_modules/nitromelondb/native/ios/.../SupportingFiles`, which is not a public include path. **Delete** those `HEADER_SEARCH_PATHS` / `SupportingFiles` entries from the pbxproj. Autolinking and the podspec set the headers.
+:::
+
 Minimum iOS deployment target is **15.1**.
 
 ## 4. Android
 
-Nitro autolinks. Remove the old JSI Gradle module if you had it:
+Nitro autolinks. **Delete** the old JSI Gradle module — do not retarget it:
 
 - `include ':watermelondb-jsi'` from `android/settings.gradle`
 - `implementation project(':watermelondb-jsi')` from `android/app/build.gradle`
 - `WatermelonDBJSIPackage` from `MainApplication`
 
-Do not register `WatermelonDBPackage` by hand — that is the old architecture. Autolinking is required.
-
-If a leftover Gradle `projectDir` still points at the old npm path, update it:
+:::danger There is no `native/android-jsi`
+A string replace of `@nozbe/watermelondb` → `nitromelondb` will produce:
 
 ```gradle
-include ':watermelondb'
-project(':watermelondb').projectDir =
-    new File(rootProject.projectDir, '../node_modules/nitromelondb/native/android')
+project(':watermelondb-jsi').projectDir =
+    new File(rootProject.projectDir, '../node_modules/nitromelondb/native/android-jsi')
 ```
+
+That path **does not exist**. Remove the whole JSI block. Do not point it at `native/android` either — that module autolinks.
+:::
+
+Do not register `WatermelonDBPackage` by hand — that is the old architecture. Autolinking is required.
 
 Keep the Proguard rule if you use it:
 
@@ -128,7 +138,9 @@ Minimum Android SDK is **24**.
 
 ## 5. Expo
 
-NitromelonDB includes an Expo config plugin. You do **not** need `@morrowdigital/watermelondb-expo-plugin` (that package wired the old Android JSI module).
+The config plugin is **optional for bare React Native**. Autolinking is what actually links SQLite. On Expo, add the plugin so prebuild keeps the New Architecture on (it **rejects** `"newArchEnabled": false`).
+
+You do **not** need `@morrowdigital/watermelondb-expo-plugin` (that package wired the old Android JSI module).
 
 ```bash
 yarn remove @morrowdigital/watermelondb-expo-plugin
@@ -148,7 +160,7 @@ Then `npx expo prebuild` (or let EAS Build do it). Development builds, EAS Build
 
 ## 6. SQLiteAdapter on React Native
 
-iOS and Android SQLite is **Nitro-only**. NativeModules interop is gone. The **old React Native architecture** (Paper / the legacy bridge) is **not supported** — enable the New Architecture (on by default in React Native 0.87).
+iOS and Android SQLite is **Nitro-only**. NativeModules interop is gone. The **old React Native architecture** (Paper / the legacy bridge) is **not supported** — enable the New Architecture (on by default in React Native 0.87; required on 0.83+ as well).
 
 ```js
 const adapter = new SQLiteAdapter({
@@ -165,49 +177,75 @@ const adapter = new SQLiteAdapter({
 
 If SQLiteAdapter cannot create a native database, install `react-native-nitro-modules` and rebuild the app — Metro reload is not enough.
 
-## 7. TypeScript (Flow and `.d.ts` are gone)
+## 7. TypeScript (Flow and hand-written `.d.ts` are gone)
 
-The library implementation is TypeScript. There is no separate `index.d.ts` tree and no Flow types.
+The library implementation is TypeScript. The **published** package ships `index.d.ts` next to compiled JS. Do **not** add `tsconfig` path aliases to `node_modules/nitromelondb/src/*.ts` or to a `.d.ts` file in isolation — those files are not what npm installs, and mapping the package onto them breaks Metro and Jest.
 
 - Delete `@nozbe/watermelondb` from Flow `[libs]` / `.flowconfig` if you had them.
-- Point TypeScript path aliases at `nitromelondb`:
+- Let TypeScript resolve `nitromelondb` from the package (no `paths` workaround).
 
-```json
-{
-  "compilerOptions": {
-    "paths": {
-      "nitromelondb": ["node_modules/nitromelondb/src/index.ts"],
-      "nitromelondb/*": ["node_modules/nitromelondb/src/*"]
-    }
-  }
-}
-```
+App model code can stay JavaScript.
 
-App model code can stay JavaScript. If you already used the old `.d.ts` types, they now come from the TypeScript sources.
+### Flow / `@nozbe/watermelondb/types` → TypeScript
+
+`@nozbe/watermelondb/types` is gone. Import replacements from `nitromelondb`:
+
+| Flow / old import | TypeScript |
+| --- | --- |
+| `RecordId` | `import type { RecordId } from 'nitromelondb'` |
+| `TableName<T>` / `ColumnName` | `import type { TableName, ColumnName } from 'nitromelondb'` |
+| `RelationId<T>` or `$Call<…>` extractors (e.g. a `NonNullableRelation` helper) | `import type { RelationId } from 'nitromelondb'` — `RelationId<Model>` is `string`; `RelationId<Model \| null>` is `string \| null` |
+| `Associations`, `RawRecord`, `DirtyRaw` | `import type { Associations } from 'nitromelondb/Model'` and `import type { RawRecord, DirtyRaw } from 'nitromelondb'` |
+| `$Diff`, `$Rest`, `$Shape` | TypeScript `Omit`, `Partial`, `Pick` |
 
 See [Flow support removed](./Advanced/Flow.md) and the [TypeScript example](https://github.com/StasDoskalenko/NitromelonDB/tree/master/examples/typescript).
 
-## 8. Platform floor
+### `@json` sanitizers
+
+`json()` is generic: `json<T>(column, (source: T) => T)`. Typed sanitizers from WatermelonDB apps type-check again. `memo` on the options object is optional (default `false`).
+
+### Custom `Model.id`
+
+`Model.id` is assignable **only** inside `collection.create()` / `prepareCreate()`:
+
+```js
+await collection.create(record => {
+  record.id = serverId
+})
+```
+
+Assigning `record.id` anywhere else throws. `_raw.id` and `prepareCreateFromDirtyRaw` still work.
+
+## 8. Jest / Metro
+
+- Move `__mocks__/@nozbe/watermelondb` to `__mocks__/nitromelondb` (and the same for any subpath mocks).
+- Do **not** path-map `nitromelondb` to unpublished `.ts` sources or to a `.d.ts` file. The published package is compiled JS at the package root.
+- That compiled JS does **not** need `transformIgnorePatterns` for `nitromelondb`.
+
+## 9. Platform floor
 
 | Requirement | WatermelonDB 0.28 | NitromelonDB |
 | --- | --- | --- |
-| Node.js | 18+ (typical) | **22+** |
-| React Native | 0.74+ in 0.28 | **0.87**, New Architecture only (old / Paper architecture is not supported) |
+| Node.js | 18+ (typical) | App Node version follows your React Native release. This repo's example/CI uses **22+**. |
+| React Native | 0.74+ in 0.28 | **New Architecture required.** Tested on **0.83+**. The example app uses 0.87 (New Architecture on by default). Old / Paper architecture is not supported. |
 | iOS | 12+ | **15.1** |
 | Android minSdk | 21 (typical) | **24** |
+| `react-native-nitro-modules` | n/a | **≥ 0.35.2** (optional peer on web) |
+| `rxjs` | transitive | **peer `^7.8.0`** |
 
 ## Checklist
 
 - [ ] `yarn remove @nozbe/watermelondb && yarn add nitromelondb`
-- [ ] `yarn add react-native-nitro-modules` (React Native iOS/Android)
-- [ ] Replace `@nozbe/watermelondb` → `nitromelondb` in imports and path aliases
-- [ ] Update leftover `node_modules/@nozbe/watermelondb` paths (Gradle / Windows)
+- [ ] Install or align `rxjs@^7.8.0` (peer). Do not leave two copies in `node_modules`.
+- [ ] `yarn add react-native-nitro-modules` if it is not already a dependency (`>=0.35.2`)
+- [ ] Replace `@nozbe/watermelondb` → `nitromelondb` in **JS/TS imports**, Jest mocks, and path aliases — not in native JSI / SupportingFiles paths
 - [ ] Remove hand-copied `pod 'WatermelonDB'` / `pod 'NitromelonDB'` / `pod 'simdjson'` / `pod 'FMDB'` lines from the Podfile
+- [ ] Delete pbxproj `SupportingFiles` / old Watermelon header search paths; do not retarget them
 - [ ] Bridging header, if you import it: `#import <NitromelonDB/WatermelonDB.h>`
-- [ ] Remove `watermelondb-jsi` / `WatermelonDBJSIPackage` from Android
+- [ ] **Delete** `watermelondb-jsi` / `WatermelonDBJSIPackage` from Android. Do not retarget `native/android-jsi`
 - [ ] Enable the New Architecture (old / Paper architecture is not supported)
 - [ ] Remove `{ jsi: false }` from `SQLiteAdapter` on iOS/Android
-- [ ] Expo: add `"nitromelondb"` to `app.json` `plugins` and remove `@morrowdigital/watermelondb-expo-plugin`
-- [ ] Full native rebuild (`npx react-native run-ios` / `run-android`, or `npx expo run:ios` / `run:android`)
+- [ ] Expo: add `"nitromelondb"` to `app.json` `plugins` and remove `@morrowdigital/watermelondb-expo-plugin`. Bare apps can skip the plugin.
+- [ ] `pod install` and a full native rebuild (`npx react-native run-ios` / `run-android`, or `npx expo run:ios` / `run:android`) — not a Metro reload
 
 Then continue with [Installation](./Installation.mdx) and [Setup](./Setup.md) if anything in native linking is still missing.

--- a/examples/typescript/__typetests__/index.ts
+++ b/examples/typescript/__typetests__/index.ts
@@ -1,2 +1,3 @@
 import './query'
 import './withObservables'
+import './json'

--- a/examples/typescript/__typetests__/json.ts
+++ b/examples/typescript/__typetests__/json.ts
@@ -1,0 +1,27 @@
+import { Model, type RelationId } from 'nitromelondb'
+import { json } from 'nitromelondb/decorators'
+
+type ContactInfo = { email: string }
+
+// Typed sanitizers must be accepted (WatermelonDB Flow treated this as any;
+// `(source: unknown) => unknown` is contravariant and rejected callbacks like this).
+const sanitizeContact = (source: ContactInfo): ContactInfo =>
+  source && typeof source.email === 'string' ? source : { email: '' }
+
+class Person extends Model {
+  static table = 'people'
+
+  @json('contact_info', sanitizeContact)
+  contactInfo!: ContactInfo
+
+  @json('contact_info', sanitizeContact, { memo: true })
+  contactInfoMemoized!: ContactInfo
+
+  @json('contact_info', sanitizeContact, {})
+  contactInfoDefaultMemo!: ContactInfo
+}
+
+export { Person }
+export const personType: Person = null as unknown as Person
+export const email: string = personType.contactInfo.email
+export const relationId: RelationId<Model> = 'record-id'

--- a/examples/typescript/yarn.lock
+++ b/examples/typescript/yarn.lock
@@ -22,10 +22,6 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"nitromelondb@link:../..":
-  version "0.0.0"
-  uid ""
-
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -1111,6 +1107,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+"nitromelondb@link:../..":
+  version "0.0.0"
+  uid ""
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -1403,7 +1403,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rxjs@^7.8.2:
+rxjs@^7.8.0:
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "jest --config=./jest.config.js --forceExit",
     "ci": "yarn ci:check",
     "test:metro-transform": "node ./scripts/check-metro-transform.mjs",
-    "ci:check": "concurrently -c auto -n jest,eslint,ts,ts-examples,metro 'npm run test' 'npm run eslint' 'npm run typecheck' 'npm run test:typescript' 'npm run test:metro-transform' --kill-others-on-fail",
+    "ci:check": "concurrently -c auto -n jest,eslint,ts,ts-examples,metro,pkg 'npm run test' 'npm run eslint' 'npm run typecheck' 'npm run test:typescript' 'npm run test:metro-transform' 'npm run test:published-package' --kill-others-on-fail",
+    "test:published-package": "node ./scripts/published-package.mjs --self-test",
     "test:android": "cd native/androidTest && ./gradlew connectedAndroidTest",
     "test:ios": "scripts/test-ios",
     "test:windows": "react-native run-windows",
@@ -73,11 +74,12 @@
     "@babel/runtime": "7.26.0",
     "hoist-non-react-statics": "^3.3.2",
     "lokijs": "npm:@nozbe/lokijs@1.5.12-wmelon8",
-    "rxjs": "^7.8.2",
+    "rxjs": "^7.8.0",
     "sql-escape-string": "^1.1.0"
   },
   "peerDependencies": {
-    "react-native-nitro-modules": "*"
+    "rxjs": "^7.8.0",
+    "react-native-nitro-modules": ">=0.35.2"
   },
   "peerDependenciesMeta": {
     "react-native-nitro-modules": {

--- a/scripts/check-metro-transform.mjs
+++ b/scripts/check-metro-transform.mjs
@@ -37,6 +37,20 @@ if (!files.length) {
   throw new Error('No TypeScript sources found to transform')
 }
 
+// Metro prefers `nitro.json` over `nitro/index.js` when the specifier is `.../nitro`.
+const nitroJsonCollision = /require\((['"])([^'"]*\/)?nitro\1\)/
+for (const file of files) {
+  if (!file.startsWith(src)) {
+    continue
+  }
+  const source = fs.readFileSync(file, 'utf8')
+  if (nitroJsonCollision.test(source)) {
+    throw new Error(
+      `${path.relative(root, file)}: require('.../nitro') resolves to package-root nitro.json in Metro. Use '.../nitro/index'.`,
+    )
+  }
+}
+
 for (const file of files) {
   const source = fs.readFileSync(file, 'utf8')
   try {

--- a/scripts/make.mjs
+++ b/scripts/make.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { pipe, filter, map, mapAsync, prop, replace, omit, merge, forEach } from 'rambdax'
+import { pipe, filter, map, mapAsync, prop, replace, forEach } from 'rambdax'
 
 import babel from '@babel/core'
 import klaw from 'klaw-sync'
@@ -17,6 +17,7 @@ import rimraf from 'rimraf'
 import { execSync } from 'child_process'
 
 import pkg from './pkg.cjs'
+import { preparePublishedPackageJson } from './published-package.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -100,15 +101,7 @@ const buildModule = (format) => (file) => {
   fs.writeFileSync(filename, code)
 }
 
-const prepareJson = pipe(
-  omit(['scripts', 'bin']),
-  merge({
-    main: './index.js',
-    sideEffects: false,
-    types: 'index.d.ts',
-  }),
-  (obj) => prettyJson(obj),
-)
+const prepareJson = (obj) => prettyJson(preparePublishedPackageJson(obj))
 
 const createPackageJson = (dir, obj) => {
   const json = prepareJson(obj)

--- a/scripts/published-package.mjs
+++ b/scripts/published-package.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Shape of package.json written into dist/ (the npm tarball).
+ *
+ * Root package.json keeps `"types": "src/index.ts"` for in-repo TypeScript.
+ * The published tarball compiles JS next to `index.d.ts` and does not include
+ * `.ts` sources, so that field must be overwritten here.
+ *
+ * Do not use Ramda `merge(defaults)(pkg)` for this: `merge` is `merge(a, b)`
+ * with `b` winning, so the root `"types": "src/index.ts"` would clobber
+ * `"index.d.ts"`.
+ */
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SUBPATH_EXPORT = {
+  types: './*/index.d.ts',
+  default: './*/index.js',
+}
+
+export const PUBLISHED_EXPORTS = {
+  '.': {
+    types: './index.d.ts',
+    default: './index.js',
+  },
+  './package.json': './package.json',
+  './app.plugin.js': './app.plugin.js',
+  './*': SUBPATH_EXPORT,
+}
+
+export function preparePublishedPackageJson(pkg) {
+  const rest = { ...pkg }
+  delete rest.scripts
+  delete rest.bin
+  return {
+    ...rest,
+    main: './index.js',
+    types: './index.d.ts',
+    sideEffects: false,
+    exports: PUBLISHED_EXPORTS,
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function runSelfTest() {
+  const fakePkg = {
+    name: 'nitromelondb',
+    types: 'src/index.ts',
+    scripts: { build: 'true' },
+    bin: { fake: './bin.js' },
+    dependencies: { rxjs: '^7.8.0' },
+    peerDependencies: {
+      rxjs: '^7.8.0',
+      'react-native-nitro-modules': '>=0.35.2',
+    },
+  }
+
+  const published = preparePublishedPackageJson(fakePkg)
+
+  assert(published.types === './index.d.ts', `types must be ./index.d.ts, got ${published.types}`)
+  assert(published.main === './index.js', `main must be ./index.js, got ${published.main}`)
+  assert(published.sideEffects === false, 'sideEffects must be false')
+  assert(published.scripts === undefined, 'scripts must be omitted')
+  assert(published.bin === undefined, 'bin must be omitted')
+  assert(published.exports['.'].types === './index.d.ts', 'exports["."] types must be ./index.d.ts')
+  assert(published.exports['./decorators'] === undefined, 'directory imports go through ./*')
+  assert(published.exports['./*'].types === './*/index.d.ts', 'subpath types must resolve */index.d.ts')
+  assert(published.exports['./app.plugin.js'] === './app.plugin.js', 'Expo plugin export missing')
+  assert(published.name === 'nitromelondb', 'package name must be preserved')
+
+  console.log('ok    types overwritten to ./index.d.ts')
+  console.log('ok    scripts/bin omitted')
+  console.log('ok    exports map present')
+  console.log('\n3 tests passed')
+}
+
+const isDirectRun =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isDirectRun && process.argv.includes('--self-test')) {
+  try {
+    runSelfTest()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}

--- a/src/Model/index.ts
+++ b/src/Model/index.ts
@@ -77,9 +77,20 @@ export default class Model {
 
   /**
    * Record's ID
+   *
+   * Assign only inside `collection.create()` / `prepareCreate()`. IDs are immutable afterwards.
    */
   get id(): RecordId {
     return this._raw.id
+  }
+
+  set id(newId: RecordId) {
+    invariant(
+      this._preparedState === 'create' && this._isEditing,
+      `Cannot set id of ${this.__debugName} after create. Assign \`record.id\` only inside \`collection.create()\` / \`prepareCreate()\`.`,
+    )
+    invariant(typeof newId === 'string' && newId.length > 0, 'Model.id must be a non-empty string')
+    this._raw.id = newId
   }
 
   /**

--- a/src/Model/test.js
+++ b/src/Model/test.js
@@ -135,6 +135,20 @@ describe('CRUD', () => {
       number: 0,
     })
   })
+  it('_prepareCreate: can set a custom id', () => {
+    const database = makeDatabase()
+    const collection = database.get('mock')
+    const m1 = MockModel._prepareCreate(collection, (record) => {
+      record.id = 'custom-id-123'
+      record.name = 'Named'
+    })
+
+    expect(m1.id).toBe('custom-id-123')
+    expect(m1.name).toBe('Named')
+    expect(() => {
+      m1.id = 'nope'
+    }).toThrow(/Cannot set id/)
+  })
   it('_prepareCreateFromDirtyRaw: can instantiate new records', () => {
     const database = makeDatabase()
     const collection = database.get('mock')
@@ -403,7 +417,7 @@ describe('Safety features', () => {
       )
     })
   })
-  it('diallows direct manipulation of id', async () => {
+  it('disallows changing id after create', async () => {
     const db = makeDatabase()
     db.adapter.batch = jest.fn()
     await db.write(async () => {
@@ -413,7 +427,7 @@ describe('Safety features', () => {
         model.update(() => {
           model.id = 'newId'
         }),
-        'Cannot set property id',
+        'Cannot set id',
       )
     })
   })

--- a/src/__typetests__/json.ts
+++ b/src/__typetests__/json.ts
@@ -1,0 +1,27 @@
+import Model from '../Model'
+import { type RelationId } from '../Relation'
+import json from '../decorators/json'
+
+type ContactInfo = { email: string }
+
+const sanitizeContact = (source: ContactInfo): ContactInfo =>
+  source && typeof source.email === 'string' ? source : { email: '' }
+
+class Person extends Model {
+  static table = 'people'
+
+  @json('contact_info', sanitizeContact)
+  contactInfo!: ContactInfo
+
+  @json('contact_info', sanitizeContact, { memo: true })
+  contactInfoMemoized!: ContactInfo
+
+  @json('contact_info', sanitizeContact, {})
+  contactInfoDefaultMemo!: ContactInfo
+}
+
+export { Person }
+
+export const personType: Person = null as unknown as Person
+export const email: string = personType.contactInfo.email
+export const relationId: RelationId<Model> = 'record-id'

--- a/src/adapters/sqlite/makeDispatcher/index.native.ts
+++ b/src/adapters/sqlite/makeDispatcher/index.native.ts
@@ -42,7 +42,8 @@ function nitromelonOrNull(): Nitromelon | null {
   }
 
   try {
-    const nitroModule = require('../../../nitro') as { nitromelon: Nitromelon }
+    // `/index` is required: Metro prefers package-root `nitro.json` over `nitro/index.js`.
+    const nitroModule = require('../../../nitro/index') as { nitromelon: Nitromelon }
     if (typeof nitroModule.nitromelon.createAdapter !== 'function') {
       cachedNitromelon = null
       return null

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,6 +1,7 @@
 export { default as action, writer, reader } from './action'
 export { default as children } from './children'
 export { default as json } from './json'
+export type { Sanitizer, Options as JsonOptions } from './json'
 export { default as nochange } from './nochange'
 export { default as field } from './field'
 export { default as date } from './date'

--- a/src/decorators/json/index.ts
+++ b/src/decorators/json/index.ts
@@ -16,11 +16,11 @@ import { ensureDecoratorUsedProperly, type ModelDecoratorHost } from '../common'
 // Examples:
 //   @json('contact_info', jsonValue => jasonValue || {}) contactInfo: ContactInfo
 
-export type Sanitizer = (source: unknown, model?: Model) => unknown
+export type Sanitizer<T = unknown> = (source: T, model?: Model) => T
 
 export type Options = {
   /** Use cached value if possible rather than sanitizing the raw value for every read. Default: `false` */
-  memo: boolean
+  memo?: boolean
 }
 
 const parseJSON = (value: unknown): unknown => {
@@ -37,9 +37,9 @@ const parseJSON = (value: unknown): unknown => {
 
 const defaultOptions: Options = { memo: false }
 
-export function json(
+export function json<T>(
   rawFieldName: ColumnName,
-  sanitizer: Sanitizer,
+  sanitizer: Sanitizer<T>,
   options: Options = defaultOptions,
 ): PropertyDecorator {
   return (target: object, key: string | symbol, descriptor?: PropertyDescriptor) => {
@@ -62,7 +62,7 @@ export function json(
         }
 
         const parsedValue = parseJSON(rawValue)
-        const sanitized = sanitizer(parsedValue, model as unknown as Model)
+        const sanitized = sanitizer(parsedValue as T, model as unknown as Model)
 
         if (options.memo) {
           model._jsonDecoratorCache = model._jsonDecoratorCache || {}
@@ -73,7 +73,7 @@ export function json(
       },
       set(this: ModelDecoratorHost, jsonValue: unknown): void {
         const model = this
-        const sanitizedValue = sanitizer(jsonValue, model as unknown as Model)
+        const sanitizedValue = sanitizer(jsonValue as T, model as unknown as Model)
         const stringifiedValue = sanitizedValue != null ? JSON.stringify(sanitizedValue) : null
 
         model.asModel._setRaw(rawFieldName, stringifiedValue)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { localStorageKey } from './Database/LocalStorage'
 export type { DatabaseAdapter } from './adapters/type'
 export type { RawRecord, DirtyRaw } from './RawRecord'
 export type { RecordId } from './Model'
+export type { RelationId } from './Relation'
 export type {
   TableName,
   ColumnName,

--- a/src/utils/common/randomId/randomId.native.ts
+++ b/src/utils/common/randomId/randomId.native.ts
@@ -13,7 +13,8 @@ function nitromelonOrNull(): Nitromelon | null {
   }
 
   try {
-    const nitroModule = require('../../../nitro') as { nitromelon: Nitromelon }
+    // `/index` is required: Metro prefers package-root `nitro.json` over `nitro/index.js`.
+    const nitroModule = require('../../../nitro/index') as { nitromelon: Nitromelon }
     if (typeof nitroModule.nitromelon.getRandomIds !== 'function') {
       cachedNitromelon = null
       return null


### PR DESCRIPTION
## Summary
- Fix the published tarball so `types` points at `index.d.ts` (Ramda `merge` was leaving `src/index.ts`, which is not in the package), add an `exports` map, make `rxjs` a `^7.8.0` peer, and pin `react-native-nitro-modules` to `>=0.35.2`.
- Make `@json` sanitizers generic, allow `record.id = …` only inside `create()` / `prepareCreate()`, and export `RelationId` from the package root.
- Stop Metro from resolving package-root `nitro.json` instead of `nitro/index.js` (release bundles never created the HybridObject).
- Update the WatermelonDB migration guide for native-path pitfalls (`android-jsi`, iOS `SupportingFiles`), Jest/Metro, Expo plugin vs autolinking, and RN 0.83+ New Architecture.

## Test plan
- [ ] `node scripts/published-package.mjs --self-test` (also runs in CI)
- [ ] `yarn test:metro-transform` (also guards against `require('.../nitro')`)
- [ ] `yarn typecheck` and `yarn test:typescript`
- [ ] `yarn test -- src/Model/test.js src/decorators/json/test.js`
- [ ] After merge, cut `0.30.0-beta.2` and confirm `npm pack` / the published `package.json` has `"types": "./index.d.ts"` and an `exports` map
- [ ] Install the beta in an app and confirm `import { Database } from 'nitromelondb'` typechecks without `tsconfig` path aliases
- [ ] Release iOS bundle: SQLite opens and `createHybridObject('Nitromelon')` is in `main.jsbundle`, not `nitro.json`