### PR TITLE
fix: publish withDatabase and DatabaseProvider JavaScript

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -8,6 +8,9 @@
 
 ### Fixes
 
+- **npm:** compile `.tsx` sources into the published tarball. `react/withDatabase.js` and `react/DatabaseProvider.js` were missing (`import from 'nitromelondb/react'` failed in Metro). The JS build only matched `.ts`/`.js`, while `tsc` still emitted their `.d.ts`.
+- **SQLite:** log the underlying error when the Nitromelon HybridObject fails to load, instead of only throwing a follow-on "install react-native-nitro-modules" message.
+
 ### Performance
 
 ### Changes

--- a/scripts/make.mjs
+++ b/scripts/make.mjs
@@ -18,6 +18,7 @@ import { execSync } from 'child_process'
 
 import pkg from './pkg.cjs'
 import { preparePublishedPackageJson } from './published-package.mjs'
+import { DO_NOT_BUILD_PATHS, isSourceFile } from './source-files.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -33,26 +34,9 @@ const DEV_PATH = process.env.DEV_PATH || resolvePath('dev')
 
 const DIR_PATH = isDevelopment ? DEV_PATH : DIST_PATH
 
-const DO_NOT_BUILD_PATHS = [
-  /__tests__/,
-  /__typetests__/,
-  /__playground__/,
-  /test\.js/,
-  /test\.ts/,
-  /integrationTest/,
-  /__mocks__/,
-  /\.DS_Store/,
-  /package\.json/,
-]
-
 const isNotIncludedInBuildPaths = (value) => !anymatch(DO_NOT_BUILD_PATHS, value)
 
 const cleanFolder = (dir) => rimraf.sync(dir)
-
-const isSourceFile = (value) =>
-  (value.endsWith('.js') || value.endsWith('.ts')) &&
-  !value.endsWith('.d.ts') &&
-  isNotIncludedInBuildPaths(value)
 
 const takeFiles = pipe(prop('path'), isSourceFile)
 
@@ -88,6 +72,23 @@ const emitDeclarations = (outDir) => {
     stdio: 'inherit',
     cwd: resolvePath(),
   })
+}
+
+const DECLARATION_ONLY = [/\/ambient\.d\.ts$/, /\/__typetests__\//]
+
+function assertDeclarationJsSiblings(buildPath) {
+  const missing = klaw(buildPath, { nodir: true })
+    .map((entry) => entry.path)
+    .filter((file) => file.endsWith('.d.ts') && !file.endsWith('.d.ts.map'))
+    .filter((file) => !DECLARATION_ONLY.some((pattern) => pattern.test(file)))
+    .filter((file) => !fs.existsSync(file.replace(/\.d\.ts$/, '.js')))
+    .map((file) => path.relative(buildPath, file))
+
+  if (missing.length) {
+    throw new Error(
+      `Published .d.ts without sibling .js (JS build skipped the source):\n${missing.join('\n')}`,
+    )
+  }
 }
 
 const buildModule = (format) => (file) => {
@@ -236,6 +237,8 @@ if (isDevelopment) {
   buildCjsModules(modules)
 
   emitDeclarations(DIST_PATH)
+  cleanFolder(`${DIST_PATH}/__typetests__`)
+  assertDeclarationJsSiblings(DIST_PATH)
 
   // copy remaining hand-written typescript definitions for unconverted modules
   glob(`${SOURCE_PATH}/**/*.d.ts`, {}, (err, files) => {

--- a/scripts/make.mjs
+++ b/scripts/make.mjs
@@ -233,17 +233,16 @@ if (isDevelopment) {
   createFolder(DIST_PATH)
   copyNonJavaScriptFiles(DIST_PATH)
 
-  buildSrcModules(modules)
-  buildCjsModules(modules)
+  await buildSrcModules(modules)
+  await buildCjsModules(modules)
 
   emitDeclarations(DIST_PATH)
   cleanFolder(`${DIST_PATH}/__typetests__`)
   assertDeclarationJsSiblings(DIST_PATH)
 
   // copy remaining hand-written typescript definitions for unconverted modules
-  glob(`${SOURCE_PATH}/**/*.d.ts`, {}, (err, files) => {
-    files.forEach((file) => {
-      fs.copySync(file, path.join(DIST_PATH, replace(SOURCE_PATH, '', file)))
-    })
+  const dtsFiles = glob.sync(`${SOURCE_PATH}/**/*.d.ts`)
+  dtsFiles.forEach((file) => {
+    fs.copySync(file, path.join(DIST_PATH, replace(SOURCE_PATH, '', file)))
   })
 }

--- a/scripts/published-package.mjs
+++ b/scripts/published-package.mjs
@@ -15,6 +15,7 @@
 
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isSourceFile } from './source-files.mjs'
 
 const SUBPATH_EXPORT = {
   types: './*/index.d.ts',
@@ -76,10 +77,24 @@ function runSelfTest() {
   assert(published.exports['./app.plugin.js'] === './app.plugin.js', 'Expo plugin export missing')
   assert(published.name === 'nitromelondb', 'package name must be preserved')
 
+  assert(isSourceFile('/src/react/withDatabase.tsx'), '.tsx files must be compiled into the tarball')
+  assert(isSourceFile('/src/react/DatabaseProvider.tsx'), '.tsx files must be compiled into the tarball')
+  assert(isSourceFile('/src/react/index.ts'), '.ts files must be compiled')
+  assert(!isSourceFile('/src/react/index.d.ts'), '.d.ts files are not Babel inputs')
+  assert(!isSourceFile('/src/react/DatabaseProvider.test.js'), 'tests must not be compiled')
+
+  const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src')
+  const requiredTsx = ['react/withDatabase.tsx', 'react/DatabaseProvider.tsx']
+  for (const rel of requiredTsx) {
+    const abs = path.join(srcRoot, rel)
+    assert(isSourceFile(abs), `${rel} would be skipped by the JS build`)
+  }
+
   console.log('ok    types overwritten to ./index.d.ts')
   console.log('ok    scripts/bin omitted')
   console.log('ok    exports map present')
-  console.log('\n3 tests passed')
+  console.log('ok    .tsx sources are included in the JS build')
+  console.log('\n4 tests passed')
 }
 
 const isDirectRun =

--- a/scripts/source-files.mjs
+++ b/scripts/source-files.mjs
@@ -1,0 +1,23 @@
+import anymatch from 'anymatch'
+
+export const DO_NOT_BUILD_PATHS = [
+  /__tests__/,
+  /__typetests__/,
+  /__playground__/,
+  /test\.js/,
+  /test\.ts/,
+  /test\.tsx/,
+  /integrationTest/,
+  /__mocks__/,
+  /\.DS_Store/,
+  /package\.json/,
+]
+
+export function isSourceFile(value) {
+  // `.tsx` does not end with `.ts` — omitting it drops DatabaseProvider / withDatabase from npm.
+  return (
+    (value.endsWith('.js') || value.endsWith('.ts') || value.endsWith('.tsx')) &&
+    !value.endsWith('.d.ts') &&
+    !anymatch(DO_NOT_BUILD_PATHS, value)
+  )
+}

--- a/src/adapters/sqlite/makeDispatcher/index.native.ts
+++ b/src/adapters/sqlite/makeDispatcher/index.native.ts
@@ -44,13 +44,17 @@ function nitromelonOrNull(): Nitromelon | null {
   try {
     // `/index` is required: Metro prefers package-root `nitro.json` over `nitro/index.js`.
     const nitroModule = require('../../../nitro/index') as { nitromelon: Nitromelon }
-    if (typeof nitroModule.nitromelon.createAdapter !== 'function') {
+    if (typeof nitroModule.nitromelon?.createAdapter !== 'function') {
       cachedNitromelon = null
       return null
     }
     cachedNitromelon = nitroModule.nitromelon
     return nitroModule.nitromelon
-  } catch {
+  } catch (error) {
+    logger.warn(
+      '[SQLite] Failed to load Nitromelon HybridObject. If the next error says to install react-native-nitro-modules, this is the underlying cause:',
+      error,
+    )
     cachedNitromelon = null
     return null
   }

--- a/src/utils/common/randomId/randomId.native.ts
+++ b/src/utils/common/randomId/randomId.native.ts
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 
 import nativeRandomId_fallback from './fallback'
+import logger from '../logger'
 import type { Nitromelon } from '../../../nitro/Nitromelon.nitro'
 
 let randomIds: string[] = []
@@ -15,13 +16,14 @@ function nitromelonOrNull(): Nitromelon | null {
   try {
     // `/index` is required: Metro prefers package-root `nitro.json` over `nitro/index.js`.
     const nitroModule = require('../../../nitro/index') as { nitromelon: Nitromelon }
-    if (typeof nitroModule.nitromelon.getRandomIds !== 'function') {
+    if (typeof nitroModule.nitromelon?.getRandomIds !== 'function') {
       cachedNitromelon = null
       return null
     }
     cachedNitromelon = nitroModule.nitromelon
     return cachedNitromelon
-  } catch {
+  } catch (error) {
+    logger.warn('[SQLite] Failed to load Nitromelon for native random IDs; using JS fallback.', error)
     cachedNitromelon = null
     return null
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/__tests__/**",
+    "src/**/__typetests__/**",
     "src/**/__playground__/**"
   ]
 }


### PR DESCRIPTION
## Summary
- Fixes #42: the JS build only compiled `.ts`/`.js`, so `react/withDatabase.tsx` and `react/DatabaseProvider.tsx` shipped as `.d.ts` with no `.js`. `import … from 'nitromelondb/react'` then failed in Metro.
- `yarn build` now fails if a published `.d.ts` has no sibling `.js`.
- When the Nitromelon HybridObject fails to load, log the underlying error instead of only throwing the follow-on “install react-native-nitro-modules” message.

## Test plan
- [ ] `node scripts/published-package.mjs --self-test`
- [ ] `yarn test -- src/react/DatabaseProvider.test.js src/react/useDatabase.test.js`
- [ ] `yarn build` and confirm `dist/react/withDatabase.js` and `dist/react/DatabaseProvider.js` exist
- [ ] `node -e "require('./dist/react/index.js')"` (or from an unpacked `npm pack`) resolves `withDatabase` / `DatabaseProvider`
- [ ] After `0.30.0-beta.3`, `import { withDatabase, DatabaseProvider } from 'nitromelondb/react'` bundles


Made with [Cursor](https://cursor.com)