### PR TITLE
fix: accept @json sanitizers whose input and output types differ

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- **`@json` sanitizers:** input and output types can differ (`(source: string) => string[]`). The previous `Sanitizer<T> = (source: T) => T` rejected real-world sanitizers and made wrapping `json()` fail.
+
 ### Performance
 
 ### Changes

--- a/docs-website/docs/docs/Advanced/AdvancedFields.md
+++ b/docs-website/docs/docs/Advanced/AdvancedFields.md
@@ -38,7 +38,7 @@ comment.update(() => {
 
 As the second argument, pass a **sanitizer function**. This is a function that receives whatever `JSON.parse()` returns for the serialized JSON, and returns whatever type you expect in your app. In other words, it turns raw, dirty, untrusted data (that might be missing, or malformed by a bug in previous version of the app) into trusted format.
 
-`json()` is generic (`json<T>(column, (source: T) => T)`), so a sanitizer typed as `(source: ContactInfo) => ContactInfo` type-checks. The sanitizer might also receive `null` if the column is nullable, or `undefined` if the field doesn't contain valid JSON.
+`json()` is generic (`json<TInput, TOutput>(column, (source: TInput) => TOutput)`). Identity sanitizers like `(source: ContactInfo) => ContactInfo` type-check, and so do transforming ones like `(source: string) => string[]` or `(raw: unknown) => string[]`. The sanitizer might also receive `null` if the column is nullable, or `undefined` if the field doesn't contain valid JSON.
 
 Pass `{ memo: true }` as a third argument to reuse the last sanitized value when the raw column has not changed. `memo` is optional and defaults to `false`.
 

--- a/docs-website/docs/docs/Migrating.md
+++ b/docs-website/docs/docs/Migrating.md
@@ -202,7 +202,7 @@ See [Flow support removed](./Advanced/Flow.md) and the [TypeScript example](http
 
 ### `@json` sanitizers
 
-`json()` is generic: `json<T>(column, (source: T) => T)`. Typed sanitizers from WatermelonDB apps type-check again. `memo` on the options object is optional (default `false`).
+`json()` is generic: `json<TInput, TOutput>(column, (source: TInput) => TOutput)`. Typed sanitizers from WatermelonDB apps type-check, including ones that change the type (`(source: string) => string[]`). `memo` on the options object is optional (default `false`).
 
 ### Custom `Model.id`
 

--- a/examples/typescript/__typetests__/json.ts
+++ b/examples/typescript/__typetests__/json.ts
@@ -8,8 +8,8 @@ type ContactInfo = { email: string }
 const sanitizeContact = (source: ContactInfo): ContactInfo =>
   source && typeof source.email === 'string' ? source : { email: '' }
 
-const accessLevelSanitizer = (accessLevels: string): string[] =>
-  typeof accessLevels === 'string' ? accessLevels.split(',') : []
+const sanitizeTags = (raw: string): string[] =>
+  typeof raw === 'string' ? raw.split(',') : []
 
 const sanitizeReactions = (raw: unknown): string[] =>
   Array.isArray(raw) ? raw.map(String) : []
@@ -26,8 +26,8 @@ class Person extends Model {
   @json('contact_info', sanitizeContact, {})
   contactInfoDefaultMemo!: ContactInfo
 
-  @json('access_levels', accessLevelSanitizer)
-  accessLevels!: string[]
+  @json('tags', sanitizeTags)
+  tags!: string[]
 
   @json('reactions', sanitizeReactions)
   reactions!: string[]
@@ -49,17 +49,17 @@ export function wrappedJsonWithOptions<T>(
   return json(rawFieldName, sanitizer, options)
 }
 
-class Account extends Model {
-  static table = 'accounts'
+class Note extends Model {
+  static table = 'notes'
 
-  @wrappedJson('access_levels', accessLevelSanitizer)
-  accessLevels!: string[]
+  @wrappedJson('tags', sanitizeTags)
+  tags!: string[]
 }
 
-export { Person, Account }
+export { Person, Note }
 export const personType: Person = null as unknown as Person
 export const email: string = personType.contactInfo.email
-export const accessLevels: string[] = personType.accessLevels
+export const tags: string[] = personType.tags
 export const reactions: string[] = personType.reactions
-export const accountAccessLevels: string[] = (null as unknown as Account).accessLevels
+export const noteTags: string[] = (null as unknown as Note).tags
 export const relationId: RelationId<Model> = 'record-id'

--- a/examples/typescript/__typetests__/json.ts
+++ b/examples/typescript/__typetests__/json.ts
@@ -1,5 +1,5 @@
 import { Model, type RelationId } from 'nitromelondb'
-import { json } from 'nitromelondb/decorators'
+import { json, type JsonOptions } from 'nitromelondb/decorators'
 
 type ContactInfo = { email: string }
 
@@ -7,6 +7,12 @@ type ContactInfo = { email: string }
 // `(source: unknown) => unknown` is contravariant and rejected callbacks like this).
 const sanitizeContact = (source: ContactInfo): ContactInfo =>
   source && typeof source.email === 'string' ? source : { email: '' }
+
+const accessLevelSanitizer = (accessLevels: string): string[] =>
+  typeof accessLevels === 'string' ? accessLevels.split(',') : []
+
+const sanitizeReactions = (raw: unknown): string[] =>
+  Array.isArray(raw) ? raw.map(String) : []
 
 class Person extends Model {
   static table = 'people'
@@ -19,9 +25,41 @@ class Person extends Model {
 
   @json('contact_info', sanitizeContact, {})
   contactInfoDefaultMemo!: ContactInfo
+
+  @json('access_levels', accessLevelSanitizer)
+  accessLevels!: string[]
+
+  @json('reactions', sanitizeReactions)
+  reactions!: string[]
 }
 
-export { Person }
+export function wrappedJson<T>(
+  rawFieldName: string,
+  sanitizer: (source: T, model?: Model) => unknown,
+  options?: Parameters<typeof json>[2],
+): PropertyDecorator {
+  return json(rawFieldName, sanitizer, options)
+}
+
+export function wrappedJsonWithOptions<T>(
+  rawFieldName: string,
+  sanitizer: (source: T, model?: Model) => unknown,
+  options?: JsonOptions,
+): PropertyDecorator {
+  return json(rawFieldName, sanitizer, options)
+}
+
+class Account extends Model {
+  static table = 'accounts'
+
+  @wrappedJson('access_levels', accessLevelSanitizer)
+  accessLevels!: string[]
+}
+
+export { Person, Account }
 export const personType: Person = null as unknown as Person
 export const email: string = personType.contactInfo.email
+export const accessLevels: string[] = personType.accessLevels
+export const reactions: string[] = personType.reactions
+export const accountAccessLevels: string[] = (null as unknown as Account).accessLevels
 export const relationId: RelationId<Model> = 'record-id'

--- a/src/__typetests__/json.ts
+++ b/src/__typetests__/json.ts
@@ -8,8 +8,8 @@ type ContactInfo = { email: string }
 const sanitizeContact = (source: ContactInfo): ContactInfo =>
   source && typeof source.email === 'string' ? source : { email: '' }
 
-const accessLevelSanitizer = (accessLevels: string): string[] =>
-  typeof accessLevels === 'string' ? accessLevels.split(',') : []
+const sanitizeTags = (raw: string): string[] =>
+  typeof raw === 'string' ? raw.split(',') : []
 
 const sanitizeReactions = (raw: unknown): string[] =>
   Array.isArray(raw) ? raw.map(String) : []
@@ -26,8 +26,8 @@ class Person extends Model {
   @json('contact_info', sanitizeContact, {})
   contactInfoDefaultMemo!: ContactInfo
 
-  @json('access_levels', accessLevelSanitizer)
-  accessLevels!: string[]
+  @json('tags', sanitizeTags)
+  tags!: string[]
 
   @json('reactions', sanitizeReactions)
   reactions!: string[]
@@ -49,18 +49,18 @@ export function wrappedJsonWithOptions<T>(
   return json(rawFieldName, sanitizer, options)
 }
 
-class Account extends Model {
-  static table = 'accounts'
+class Note extends Model {
+  static table = 'notes'
 
-  @wrappedJson('access_levels', accessLevelSanitizer)
-  accessLevels!: string[]
+  @wrappedJson('tags', sanitizeTags)
+  tags!: string[]
 }
 
-export { Person, Account }
+export { Person, Note }
 
 export const personType: Person = null as unknown as Person
 export const email: string = personType.contactInfo.email
-export const accessLevels: string[] = personType.accessLevels
+export const tags: string[] = personType.tags
 export const reactions: string[] = personType.reactions
-export const accountAccessLevels: string[] = (null as unknown as Account).accessLevels
+export const noteTags: string[] = (null as unknown as Note).tags
 export const relationId: RelationId<Model> = 'record-id'

--- a/src/__typetests__/json.ts
+++ b/src/__typetests__/json.ts
@@ -1,11 +1,18 @@
 import Model from '../Model'
 import { type RelationId } from '../Relation'
 import json from '../decorators/json'
+import type { JsonOptions } from '../decorators'
 
 type ContactInfo = { email: string }
 
 const sanitizeContact = (source: ContactInfo): ContactInfo =>
   source && typeof source.email === 'string' ? source : { email: '' }
+
+const accessLevelSanitizer = (accessLevels: string): string[] =>
+  typeof accessLevels === 'string' ? accessLevels.split(',') : []
+
+const sanitizeReactions = (raw: unknown): string[] =>
+  Array.isArray(raw) ? raw.map(String) : []
 
 class Person extends Model {
   static table = 'people'
@@ -18,10 +25,42 @@ class Person extends Model {
 
   @json('contact_info', sanitizeContact, {})
   contactInfoDefaultMemo!: ContactInfo
+
+  @json('access_levels', accessLevelSanitizer)
+  accessLevels!: string[]
+
+  @json('reactions', sanitizeReactions)
+  reactions!: string[]
 }
 
-export { Person }
+export function wrappedJson<T>(
+  rawFieldName: string,
+  sanitizer: (source: T, model?: Model) => unknown,
+  options?: Parameters<typeof json>[2],
+): PropertyDecorator {
+  return json(rawFieldName, sanitizer, options)
+}
+
+export function wrappedJsonWithOptions<T>(
+  rawFieldName: string,
+  sanitizer: (source: T, model?: Model) => unknown,
+  options?: JsonOptions,
+): PropertyDecorator {
+  return json(rawFieldName, sanitizer, options)
+}
+
+class Account extends Model {
+  static table = 'accounts'
+
+  @wrappedJson('access_levels', accessLevelSanitizer)
+  accessLevels!: string[]
+}
+
+export { Person, Account }
 
 export const personType: Person = null as unknown as Person
 export const email: string = personType.contactInfo.email
+export const accessLevels: string[] = personType.accessLevels
+export const reactions: string[] = personType.reactions
+export const accountAccessLevels: string[] = (null as unknown as Account).accessLevels
 export const relationId: RelationId<Model> = 'record-id'

--- a/src/decorators/json/index.ts
+++ b/src/decorators/json/index.ts
@@ -15,7 +15,7 @@ import { ensureDecoratorUsedProperly, type ModelDecoratorHost } from '../common'
 //
 // Examples:
 //   @json('contact_info', jsonValue => jasonValue || {}) contactInfo: ContactInfo
-//   @json('access_levels', (raw: unknown) => Array.isArray(raw) ? raw.map(String) : []) accessLevels: string[]
+//   @json('tags', (raw: unknown) => Array.isArray(raw) ? raw.map(String) : []) tags: string[]
 
 export type Sanitizer<TInput = unknown, TOutput = TInput> = (
   source: TInput,

--- a/src/decorators/json/index.ts
+++ b/src/decorators/json/index.ts
@@ -15,8 +15,12 @@ import { ensureDecoratorUsedProperly, type ModelDecoratorHost } from '../common'
 //
 // Examples:
 //   @json('contact_info', jsonValue => jasonValue || {}) contactInfo: ContactInfo
+//   @json('access_levels', (raw: unknown) => Array.isArray(raw) ? raw.map(String) : []) accessLevels: string[]
 
-export type Sanitizer<T = unknown> = (source: T, model?: Model) => T
+export type Sanitizer<TInput = unknown, TOutput = TInput> = (
+  source: TInput,
+  model?: Model,
+) => TOutput
 
 export type Options = {
   /** Use cached value if possible rather than sanitizing the raw value for every read. Default: `false` */
@@ -37,9 +41,9 @@ const parseJSON = (value: unknown): unknown => {
 
 const defaultOptions: Options = { memo: false }
 
-export function json<T>(
+export function json<TInput = unknown, TOutput = TInput>(
   rawFieldName: ColumnName,
-  sanitizer: Sanitizer<T>,
+  sanitizer: Sanitizer<TInput, TOutput>,
   options: Options = defaultOptions,
 ): PropertyDecorator {
   return (target: object, key: string | symbol, descriptor?: PropertyDescriptor) => {
@@ -62,7 +66,7 @@ export function json<T>(
         }
 
         const parsedValue = parseJSON(rawValue)
-        const sanitized = sanitizer(parsedValue as T, model as unknown as Model)
+        const sanitized = sanitizer(parsedValue as TInput, model as unknown as Model)
 
         if (options.memo) {
           model._jsonDecoratorCache = model._jsonDecoratorCache || {}
@@ -73,7 +77,7 @@ export function json<T>(
       },
       set(this: ModelDecoratorHost, jsonValue: unknown): void {
         const model = this
-        const sanitizedValue = sanitizer(jsonValue as T, model as unknown as Model)
+        const sanitizedValue = sanitizer(jsonValue as TInput, model as unknown as Model)
         const stringifiedValue = sanitizedValue != null ? JSON.stringify(sanitizedValue) : null
 
         model.asModel._setRaw(rawFieldName, stringifiedValue)


### PR DESCRIPTION
## Summary
- `@json` sanitizers can now have different input and output types (`(source: string) => string[]`), matching real WatermelonDB apps.
- Wrapping `json()` no longer needs unsafe casts; identity sanitizers like `(source: ContactInfo) => ContactInfo` still type-check.
- Type tests cover transforming sanitizers and a wrapper that uses `Parameters<typeof json>` / `JsonOptions`.

## Test plan
- [ ] Confirm `@json('tags', (raw: string) => string[])` type-checks
- [ ] Confirm a wrapper `json(column, (source: T) => unknown, options?)` type-checks without a cast
- [ ] Confirm existing identity sanitizers still type-check (`yarn test:typescript`)
- [ ] Confirm json decorator runtime tests still pass (`npx jest src/decorators/json/test.js`)