### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/StasDoskalenko/NitromelonDB/security/code-scanning/7](https://github.com/StasDoskalenko/NitromelonDB/security/code-scanning/7)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.

Best single fix without changing functionality:
- In `.github/workflows/ci.yml`, insert at workflow root (after `on:` block and before `jobs:`):
  - `permissions:`
  - `contents: read`

This satisfies CodeQL’s requirement and preserves current behavior for read-only operations (checkout, dependency install, tests, linting). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
