### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   build:
     name: Build Docusaurus
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/StasDoskalenko/NitromelonDB/security/code-scanning/2](https://github.com/StasDoskalenko/NitromelonDB/security/code-scanning/2)

Add an explicit `permissions` block for the `build` job in `.github/workflows/docs.yml` so the job’s token is restricted to the minimum required scope.

Best fix (without changing behavior):  
- In the `jobs.build` section, add:
  - `permissions:`
  - `contents: read`
- Keep existing `deploy` job permissions unchanged (`pages: write`, `id-token: write`) since they are required for GitHub Pages deployment.

This scopes `build` to read-only repository access while preserving current workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
