### PR TITLE
fix: don't crash web init when performance.now is not a function

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- **Web:** init no longer crashes when `window.performance.now` exists but is not a function (`now.bind is not a function`). Timing falls back to `Date.now`. ([#46](https://github.com/StasDoskalenko/NitromelonDB/issues/46))
 - **Windows:** SQLite integration tests run Nitro turbo-sync (`unsafeLoadFromSync` / `provideSyncJson`) instead of expecting those APIs to be missing. Memory URI databases open with `SQLITE_OPEN_URI` and use an in-memory journal so WAL files are not created in a packaged app's cwd. The CI integration app embeds a dev JS bundle (`UseDevBundle=true`) so the suite runs the same DEV assertions as iOS/Android.
 
 ### Performance

--- a/src/utils/common/devMeasureTime/index.ts
+++ b/src/utils/common/devMeasureTime/index.ts
@@ -1,7 +1,11 @@
 const getPreciseTimeFunction: () => () => number = () => {
-  if (typeof global !== 'undefined' && global.nativePerformanceNow) {
+  if (typeof global !== 'undefined' && typeof global.nativePerformanceNow === 'function') {
     return global.nativePerformanceNow;
-  } else if (typeof window !== 'undefined' && window.performance && window.performance.now) {
+  } else if (
+    typeof window !== 'undefined' &&
+    window.performance &&
+    typeof window.performance.now === 'function'
+  ) {
     return window.performance.now.bind(window.performance);
   }
 

--- a/src/utils/common/devMeasureTime/test.js
+++ b/src/utils/common/devMeasureTime/test.js
@@ -1,0 +1,54 @@
+describe('getPreciseTime', () => {
+  const originalWindow = global.window
+  const originalNativePerformanceNow = global.nativePerformanceNow
+
+  const restoreGlobals = () => {
+    if (originalWindow === undefined) {
+      delete global.window
+    } else {
+      global.window = originalWindow
+    }
+    if (originalNativePerformanceNow === undefined) {
+      delete global.nativePerformanceNow
+    } else {
+      global.nativePerformanceNow = originalNativePerformanceNow
+    }
+  }
+
+  afterEach(() => {
+    restoreGlobals()
+  })
+
+  const loadGetPreciseTime = () => {
+    let getPreciseTime
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      ;({ getPreciseTime } = require('./index'))
+    })
+    return getPreciseTime
+  }
+
+  it('does not throw when window.performance.now exists but is not a function', () => {
+    delete global.nativePerformanceNow
+    global.window = {
+      performance: {
+        now: 12345,
+      },
+    }
+
+    const getPreciseTime = loadGetPreciseTime()
+    expect(typeof getPreciseTime()).toBe('number')
+  })
+
+  it('uses window.performance.now when it is a function', () => {
+    delete global.nativePerformanceNow
+    const now = jest.fn(() => 42)
+    global.window = {
+      performance: { now },
+    }
+
+    const getPreciseTime = loadGetPreciseTime()
+    expect(getPreciseTime()).toBe(42)
+    expect(now).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Guard `window.performance.now` and `nativePerformanceNow` with `typeof === 'function'` before calling `.bind`, so web init no longer throws `now.bind is not a function` when `now` is present but not callable.
- Fall back to `Date.now` in that case. Fixes #46 (upstream Nozbe/WatermelonDB#1962).

## Test plan
- [ ] `yarn jest src/utils/common/devMeasureTime/test.js --forceExit`
- [ ] Confirm a LokiJSAdapter web app still inits when `performance.now` is a real function
- [ ] Confirm init no longer throws if `performance.now` is a truthy non-function (for example a number)