### PR TITLE
ci: add CodeQL advanced setup for PR alert comparison

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: NitromelonDB CodeQL
+
+# Skip vendored, generated, and build output. First-party native code in
+# native/shared, native/nitro, native/android, native/ios, and native/windows
+# is still analyzed (C/C++ uses build-mode: none, which honors these paths).
+paths-ignore:
+  - '**/node_modules/**'
+  - '**/.yarn/**'
+  - native/vendor/**
+  - '**/Pods/**'
+  - nitrogen/generated/**
+  - dist/**
+  - docs-build/**
+  - docs-website/build/**
+  - '**/AppPackages/**'
+  - coverage/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+# Advanced CodeQL setup. Matches the languages GitHub default setup detected
+# on master (actions, c-cpp, javascript-typescript, ruby) so pull requests
+# can compare alerts. Uses build-mode: none for C/C++ (no native compile).
+#
+# After this workflow has run on master, disable Default setup in
+# Settings → Code security → Code scanning to avoid duplicate scans.
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '27 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: ruby
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add a CodeQL workflow that always analyzes the same four languages GitHub default setup already scans on `master`: Actions, C/C++, JavaScript/TypeScript, and Ruby.
- Upload results under `/language:...` so pull-request code scanning can compare alerts instead of reporting missing configurations.
- Ignore vendored and generated trees (`native/vendor`, CocoaPods, `nitrogen/generated`, build output) so scans stay on first-party code. C/C++ uses `build-mode: none` (no native compile).

## Test plan
- [ ] Confirm the `CodeQL / Analyze (...)` jobs run on this PR for all four languages
- [ ] After merge, confirm a scan runs on `master`
- [ ] Disable **Default setup** in Settings → Code security → Code scanning so default and advanced scans do not both run
- [ ] Open a follow-up PR and confirm the "4 configurations not found" warning is gone

Made with [Cursor](https://cursor.com)