### PR TITLE
ci: fix docs Pages build on Yarn 4 and skip unrelated pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
       - run: node scripts/prepare-changelog.mjs --self-test
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v4
-      - name: Check docs build
-        run: cd docs-website && yarn install --immutable && cd .. && yarn docs:build
   ios:
     runs-on: macos-26
     name: iOS tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,29 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs-website/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'scripts/update-docusaurus'
+      - 'scripts/rewrite-readme-docs-links.mjs'
+      - 'scripts/replace-docs-path.mjs'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs-website/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'scripts/update-docusaurus'
+      - 'scripts/rewrite-readme-docs-links.mjs'
+      - 'scripts/replace-docs-path.mjs'
+      - '.github/workflows/docs.yml'
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -19,6 +38,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Enable Corepack
+        run: corepack enable
       - name: Set Node.js version
         uses: actions/setup-node@v4
         with:
@@ -28,15 +49,20 @@ jobs:
       - name: Install docs dependencies
         run: yarn install --immutable
         working-directory: docs-website
+      - name: Sync markdown into Docusaurus
+        run: ./scripts/update-docusaurus
       - name: Build website
-        run: yarn docs:build
+        run: yarn build
+        working-directory: docs-website
       - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs-website/build
 
   deploy:
     name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     permissions:
       pages: write

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -14,5 +14,6 @@
 
 ### Internal
 
+- Docs Pages workflow builds with Yarn 4 inside `docs-website` (root `yarn docs:build` needs a root install) and only runs when docs-related paths change.
 - Migrate the repo and example apps from Yarn Classic to Yarn 4.18 (`node-modules` linker, pinned via `packageManager` / `.yarn/releases`).
 - Drop `patch-package` from the library root. There was no root `patches/` directory; the Expo `expo-modules-jsi` workaround stays in the example apps.

--- a/docs-website/README.md
+++ b/docs-website/README.md
@@ -28,7 +28,7 @@ This command generates static content into the `build` directory and can be serv
 
 Docs are published to GitHub Pages at https://stasdoskalenko.github.io/NitromelonDB/.
 
-Merges to `master` run `.github/workflows/docs.yml`, which builds Docusaurus and deploys with `actions/deploy-pages`. Enable **Settings → Pages → Source: GitHub Actions** in the repository if the site is not live yet.
+Merges to `master` that touch `docs-website/` (or README / CHANGELOG / CONTRIBUTING) run `.github/workflows/docs.yml`, which builds Docusaurus and deploys with `actions/deploy-pages`. Pull requests with the same path changes only build. Enable **Settings → Pages → Source: GitHub Actions** in the repository if the site is not live yet.
 
 Local build (same command CI uses):
 


### PR DESCRIPTION
## Summary
- Fix the GitHub Pages docs build after the Yarn 4 migration: install and `yarn build` inside `docs-website` instead of running root `yarn docs:build` (which needs a root install-state).
- Run the docs workflow only when docs-related paths change (`docs-website/**`, README / CHANGELOG / CONTRIBUTING, and the copy scripts). Pull requests only build; deploy stays on `master`.
- Drop the docs build from the JavaScript CI job so every PR does not rebuild the site.

## Test plan
- [ ] Confirm this PR triggers **Deploy docs** and the Docusaurus build succeeds
- [ ] After merge, confirm Pages deploys (this also recovers from the failed master run)
- [ ] Confirm a later non-docs push to `master` does not start the docs workflow

Made with [Cursor](https://cursor.com)