### PR TITLE
ci: add CodeQL manual builds for Java/Kotlin and Swift

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,7 +2,8 @@ name: NitromelonDB CodeQL
 
 # Skip vendored, generated, and build output. First-party native code in
 # native/shared, native/nitro, native/android, native/ios, and native/windows
-# is still analyzed (C/C++ uses build-mode: none, which honors these paths).
+# is still analyzed. C/C++ uses build-mode: none. Java/Kotlin and Swift use
+# manual builds in .github/workflows/codeql.yml.
 paths-ignore:
   - '**/node_modules/**'
   - '**/.yarn/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
-# Advanced CodeQL setup. Matches the languages GitHub default setup detected
-# on master (actions, c-cpp, javascript-typescript, ruby) so pull requests
-# can compare alerts. Uses build-mode: none for C/C++ (no native compile).
+# Advanced CodeQL setup. Analyzes actions, c-cpp, javascript-typescript, and
+# ruby without a compile (build-mode: none). Java/Kotlin and Swift need a real
+# build so CodeQL can trace javac/kotlinc and xcodebuild; Default setup cannot
+# find a root Gradle or Xcode project in this repo.
 #
 # After this workflow has run on master, disable Default setup in
 # Settings → Code security → Code scanning to avoid duplicate scans.
@@ -22,8 +23,8 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     permissions:
       security-events: write
       packages: read
@@ -36,16 +37,85 @@ jobs:
         include:
           - language: actions
             build-mode: none
+            runner: ubuntu-latest
+            timeout-minutes: 60
           - language: c-cpp
             build-mode: none
+            runner: ubuntu-latest
+            timeout-minutes: 60
           - language: javascript-typescript
             build-mode: none
+            runner: ubuntu-latest
+            timeout-minutes: 60
           - language: ruby
             build-mode: none
+            runner: ubuntu-latest
+            timeout-minutes: 60
+          - language: java-kotlin
+            build-mode: manual
+            runner: ubuntu-24.04
+            timeout-minutes: 60
+          - language: swift
+            build-mode: manual
+            runner: macos-26
+            timeout-minutes: 120
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Java
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set Node.js version
+        if: matrix.build-mode == 'manual'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: Cache node_modules
+        if: matrix.build-mode == 'manual'
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install JS dependencies
+        if: matrix.build-mode == 'manual'
+        run: yarn install --immutable
+
+      - name: Set up Android SDK
+        if: matrix.language == 'java-kotlin'
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        if: matrix.language == 'java-kotlin'
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set Xcode version
+        if: matrix.language == 'swift'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache CocoaPods
+        if: matrix.language == 'swift'
+        uses: actions/cache@v4
+        with:
+          path: native/iosTest/Pods
+          key: ${{ runner.os }}-pods-cache-${{ hashFiles('**/Podfile.lock') }}
+
+      - name: Install Ruby gems
+        if: matrix.language == 'swift'
+        run: bundle install
+
+      - name: Install CocoaPods
+        if: matrix.language == 'swift'
+        run: yarn cocoapods
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -53,6 +123,26 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Build Java/Kotlin
+        if: matrix.language == 'java-kotlin'
+        working-directory: native/androidTest
+        run: ./gradlew :watermelondb:compileDebugJavaWithJavac :watermelondb:compileDebugKotlin :app:compileDebugKotlin -PreactNativeArchitectures=arm64-v8a
+
+      - name: Build Swift
+        if: matrix.language == 'swift'
+        run: |
+          xcodebuild \
+            -workspace native/iosTest/WatermelonTester.xcworkspace \
+            -scheme WatermelonTester \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath native/iosTest/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -13,6 +13,7 @@
 ### Changes
 
 ### Internal
+- CodeQL: build Java/Kotlin from `native/androidTest` and Swift from `WatermelonTester` so default-setup autobuild is not required.
 - Simplified `AGENTS.md` / added Claude Code rules and cwd hooks so agents stop mixing up the library root with `examples/NotesApp`.
 - NotesApp: disable the Expo dev menu / FAB / onboarding overlay on launch so Maestro e2e can tap the UI.
 - NotesApp: sticky FlashList pager (`Q.skip` + `Q.take(20)`), UI moved under `src/`, Maestro flows for cold start, CRUD, kill-and-relaunch, interaction burst, and pagination.


### PR DESCRIPTION
## Summary
- Default CodeQL setup fails for `java-kotlin` and `swift` because this repo has no root Gradle or Xcode project.
- Advanced setup now traces `native/androidTest` (`compileDebugJavaWithJavac` / `compileDebugKotlin`) and `WatermelonTester` (`xcodebuild`) so those languages scan.
- Existing none-build jobs (Actions, C/C++, JS/TS, Ruby) are unchanged.

## Test plan
- [ ] Confirm the CodeQL workflow on this PR: `java-kotlin` and `swift` jobs succeed (not only the none-build languages).
- [ ] After merge, disable **Default setup** in Settings → Code security → Code scanning so the leftover failed default configs go away and scans are not duplicated.
