### PR TITLE
ci: cut NotesApp iOS build time — single arch + real ccache wiring

### DIFF
--- a/scripts/ccache-clang
+++ b/scripts/ccache-clang
@@ -28,15 +28,22 @@ done
 
 xcode_toolchain_dir="${xcode_toolchain_dir:?CCACHE_HACK_TOOLCHAIN_DIR not found. See ccache-clang for more details}"
 
+# Invoked as ccache-clang++ (symlink) for C++/Obj-C++ pods (e.g. Reanimated,
+# Worklets) — same toolchain-resolution dance, just the other compiler.
+compiler_name="clang"
+case "$(basename "$0")" in
+*++) compiler_name="clang++" ;;
+esac
+
 # Xcode 26 can pass Metal.xctoolchain as TOOLCHAIN_DIR. That bundle has no clang,
 # which breaks CI with: execute_noreturn of .../Metal.xctoolchain/usr/bin/clang
-clang_bin="${xcode_toolchain_dir}/usr/bin/clang"
+clang_bin="${xcode_toolchain_dir}/usr/bin/${compiler_name}"
 if [ ! -x "$clang_bin" ]; then
   default_toolchain="$(xcode-select -p 2>/dev/null)/Toolchains/XcodeDefault.xctoolchain"
-  if [ -x "${default_toolchain}/usr/bin/clang" ]; then
-    clang_bin="${default_toolchain}/usr/bin/clang"
+  if [ -x "${default_toolchain}/usr/bin/${compiler_name}" ]; then
+    clang_bin="${default_toolchain}/usr/bin/${compiler_name}"
   else
-    clang_bin="$(xcrun --find clang 2>/dev/null || command -v clang)"
+    clang_bin="$(xcrun --find "$compiler_name" 2>/dev/null || command -v "$compiler_name")"
   fi
 fi
 

--- a/scripts/ccache-clang++
+++ b/scripts/ccache-clang++
@@ -1,0 +1,1 @@
+ccache-clang

--- a/scripts/ci-notesapp-ios-maestro.sh
+++ b/scripts/ci-notesapp-ios-maestro.sh
@@ -27,12 +27,30 @@ xcrun simctl bootstatus "$SIM_UDID" -b
 
 # set -o pipefail (part of -euo pipefail above) makes this fail on a real
 # xcodebuild error, not just on xcbeautify's own exit code.
+#
+# CC/CPLUSPLUS route compilation through ccache (see scripts/ccache-clang) —
+# ios/ is Expo-generated fresh every run, so there's no project file to bake
+# this into the way native/iosTest's .xcodeproj does; command-line overrides
+# apply it without touching the generated project.
+#
+# ONLY_ACTIVE_ARCH=YES: the generated project only sets this for Debug, so
+# Release was building both arm64 and x86_64 simulator slices — double the
+# compile work for an arch (x86_64) nothing here ever runs on.
+#
+# GCC_PREPROCESSOR_DEFINITIONS below is single-quoted on purpose: its
+# $(DT_TOOLCHAIN_DIR)/$(inherited) are xcodebuild's own macro syntax, resolved
+# by Xcode, not the shell.
+# shellcheck disable=SC2016
 xcodebuild \
   -workspace ios/NotesApp.xcworkspace \
   -scheme NotesApp \
   -configuration Release \
   -destination "id=$SIM_UDID" \
   -derivedDataPath ios/build \
+  CC="$PWD/../../scripts/ccache-clang" \
+  CPLUSPLUS="$PWD/../../scripts/ccache-clang++" \
+  GCC_PREPROCESSOR_DEFINITIONS='CCACHE_HACK_TOOLCHAIN_DIR="$(DT_TOOLCHAIN_DIR)" $(inherited)' \
+  ONLY_ACTIVE_ARCH=YES \
   build | xcbeautify --renderer github-actions
 
 APP_PATH=$(find ios/build/Build/Products/Release-iphonesimulator -maxdepth 1 -name '*.app' -print -quit)


### PR DESCRIPTION
## Summary

The `notesapp-ios` job's `run tests` step took **31.3 minutes** on the run right after it landed on master — everything else in the job combined is under 5 minutes. Read the raw log ([job](https://github.com/StasDoskalenko/NitromelonDB/actions/runs/32683612552/job/97304697947)) and found two real, fixable causes:

1. **Building both simulator architectures for nothing.** The Expo-generated project only sets `ONLY_ACTIVE_ARCH=YES` for Debug, so the Release build (what CI runs) was compiling for both `arm64` and `x86_64` — a GitHub macOS runner only ever needs `arm64`. Confirmed in the raw log: both `-arch arm64` and `-arch x86_64` invocations present. Fixed by passing `ONLY_ACTIVE_ARCH=YES` as a command-line `xcodebuild` override.
2. **`ccache` was installed but never actually used.** The `ccache` step (`hendrikmuhs/ccache-action`) was already in the job, but nothing routed compilation through it — it was a pure no-op. `native/iosTest`'s `.xcodeproj` wires this by hardcoding `CC` to `scripts/ccache-clang` in its committed build settings; the Expo-generated `ios/NotesApp.xcodeproj` can't be hand-edited the same way since it's regenerated fresh on every run. Fixed by passing `CC`/`CPLUSPLUS` as command-line overrides instead, pointing at `ccache-clang` (now also usable as `clang++` via a new same-name-detecting `ccache-clang++` symlink, for the C++/Obj-C++-heavy pods — Reanimated, Worklets — that account for most of the actual compile time).

Also: the "logs are too massive" complaint was already addressed in #82 (piping through `xcbeautify`) — a from-scratch build's log went from 50k+ lines to ~11.6k. And to be clear on a side question that came up: the job wasn't actually stuck — `gh`'s log-fetch API is just laggy (~8 min behind) for in-progress jobs; the step had genuinely finished.

## Test plan
- [x] Verified locally end-to-end with the actual `scripts/ci-notesapp-ios-maestro.sh`: prebuild, `pod install`, this `xcodebuild` invocation, install, launch — `Build Succeeded`, full `maestro/` suite passes 6/6
- [x] `shellcheck` clean on both modified scripts
- [x] `node scripts/lint-workflows.mjs` clean (no workflow changes in this PR, sanity-checked anyway)
- [ ] CI: `notesapp-ios` green, and noticeably faster than the 31m baseline

Note on timing: I couldn't get a clean local before/after comparison — Xcode's global module cache (`~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex`) is already warm from this session's many local builds regardless of local `derivedData` state, so local timing doesn't reflect a genuinely cold build. The real read on both fixes — especially the ccache win, which needs a populated cache to pay off — will be this PR's actual CI run, and more so the *next* run after that once ccache's GH Actions cache has something to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)