### PR TITLE
fix: stop leaking adapter internals / fix Database.get(ModelClass) inference

### DIFF
--- a/examples/NotesApp/src/database.ts
+++ b/examples/NotesApp/src/database.ts
@@ -4,7 +4,7 @@ import { Platform } from 'react-native'
 import SQLiteAdapter from 'nitromelondb/adapters/sqlite'
 import Note from './model/Note'
 import { migrations } from './model/migrations'
-import { NOTES_TABLE, schema } from './model/schema'
+import { schema } from './model/schema'
 
 export type ExampleDatabase = {
   database: Database
@@ -30,7 +30,7 @@ export function createExampleDatabase(): ExampleDatabase {
 
   return {
     database,
-    notes: database.get<Note>(NOTES_TABLE),
+    notes: database.get(Note),
     schemaVersion: schema.version,
     sqliteEngine: adapter.dispatcherType === 'nitro' ? 'Nitro SQLite' : adapter.dispatcherType,
   }

--- a/examples/NotesApp/src/database.ts
+++ b/examples/NotesApp/src/database.ts
@@ -32,6 +32,6 @@ export function createExampleDatabase(): ExampleDatabase {
     database,
     notes: database.get<Note>(NOTES_TABLE),
     schemaVersion: schema.version,
-    sqliteEngine: adapter._dispatcherType === 'nitro' ? 'Nitro SQLite' : adapter._dispatcherType,
+    sqliteEngine: adapter.dispatcherType === 'nitro' ? 'Nitro SQLite' : adapter.dispatcherType,
   }
 }

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -29,6 +29,14 @@ export type DatabaseProps = {
   experimentalDetectNestedWriters?: boolean | undefined
 }
 
+// Deliberately not ModelClass<T>: that type's own static methods reference Collection<Record>,
+// which makes it impossible for TS to *infer* T from a concrete class passed at a call site
+// (e.g. `database.get(Note)`) — the inference only resolves down to `T = Model`, even though
+// an explicit `database.get<Note>(Note)` type-checks fine. This minimal shape (a constructor
+// returning T, plus the one field get() actually reads) is exactly what inference needs and
+// nothing more.
+type ModelClassRef<T extends Model> = { new (...args: never[]): T; table: TableName<T> }
+
 type TableChange = [TableName, CollectionChangeSet<Model>]
 
 let experimentalAllowsFatalError = false
@@ -92,8 +100,8 @@ export default class Database {
    * arbitrary string), so prefer this form where you can.
    */
   get<T extends Model>(tableName: TableName<T>): Collection<T>
-  get<T extends Model>(modelClass: ModelClass<T>): Collection<T>
-  get<T extends Model>(tableNameOrModelClass: TableName<T> | ModelClass<T>): Collection<T> {
+  get<T extends Model>(modelClass: ModelClassRef<T>): Collection<T>
+  get<T extends Model>(tableNameOrModelClass: TableName<T> | ModelClassRef<T>): Collection<T> {
     const tableName =
       typeof tableNameOrModelClass === 'string'
         ? tableNameOrModelClass

--- a/src/adapters/sqlite/index.ts
+++ b/src/adapters/sqlite/index.ts
@@ -117,6 +117,13 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     return this._initPromise
   }
 
+  // Which SQLite dispatcher is actually backing this adapter (`_dispatcherType` is an
+  // internal implementation detail; this is the public, stable way to read it — e.g. for a
+  // diagnostics/about screen).
+  get dispatcherType(): DispatcherType {
+    return this._dispatcherType
+  }
+
   async testClone(options: Partial<SQLiteAdapterOptions> = {}): Promise<SQLiteAdapter> {
     const clone = new SQLiteAdapter({
       dbName: this.dbName,


### PR DESCRIPTION
## Summary
- `SQLiteAdapter` gains a public `dispatcherType` getter; NotesApp's diagnostics label no longer reaches into the private `_dispatcherType` field to build it.
- `Database.get(ModelClass)` never actually inferred `T` from a concrete class (`database.get(Note)` silently fell back to `Collection<Model>`) — `ModelClass<T>`'s own static methods reference `Collection<Record>`, which is self-referential in a way TypeScript's inference can't unwind (an explicit `database.get<Note>(Note)` type-checked fine; only inference was broken). The `get(modelClass)` overload now uses a minimal `ModelClassRef<T>` (just the constructor + `.table`) instead of the full `ModelClass<T>`, which resolves inference without touching `ModelClass<T>` itself. NotesApp's `database.get<Note>(NOTES_TABLE)` is now `database.get(Note)`, matching what the doc comment already claimed this form does.

## Test plan
- [x] `yarn typecheck` (library)
- [x] `tsc --noEmit` in `examples/NotesApp`
- [x] `yarn test` (88 suites / 854 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)