### PR TITLE
feat: rebuild NotesApp on nitromelondb/hooks (useQuery, useObservable, useWriter)

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -29,6 +29,7 @@
 ### Changes
 
 - NotesApp: the 100-note demo seed moved from a `useEffect` in `useNotes.ts` (with its own `localStorage` idempotency flag, racing the first render's count subscription) to `database.ts`'s new `seed: { version, run }` option, which now owns that idempotency and ordering.
+- NotesApp: rebuilt on top of this release's own hooks. `useNotes.ts`'s hand-rolled `useState`/`useEffect` pair (manual subscribe/unsubscribe, a `cancelled` flag) is now `useQuery` for the page of notes plus `useObservable(query.observeCount())` for the total. Pin/delete moved from a `NotesScreen`-level `deletingIds` `Set` threaded through `NotesList`/`NotesList.windows` as props into `NoteCard` itself, using `useWriter` for `isPending`/`error` per row instead of hand-tracked state (`Note#togglePinned`/`deleteForever` dropped `@writer` since they're now invoked from inside `useWriter`'s own `database.write()`, and nesting would deadlock).
 - NotesApp Windows renders the Expo NotesApp `src/` UI (shared screen/components/model). List on Windows is `NotesList.windows.tsx`.
 - NotesApp Windows: `yarn metro`, `yarn metro:kill`, `yarn build:debug` / `build:release` / `build:all`, `yarn start:debug` / `start:release`.
 

--- a/examples/NotesApp/src/components/NoteCard.tsx
+++ b/examples/NotesApp/src/components/NoteCard.tsx
@@ -1,4 +1,5 @@
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native'
+import { useWriter } from 'nitromelondb/hooks'
 import type Note from '../model/Note'
 import { colors } from '../theme'
 import { formatTime } from '../utils/formatTime'
@@ -6,11 +7,19 @@ import { noteDeleteTestID, notePinTestID } from '../utils/noteTestIds'
 
 type NoteCardProps = {
   note: Note
-  isDeleting: boolean
-  onDelete: (note: Note) => void
+  onError?: (message: string) => void
 }
 
-export function NoteCard({ note, isDeleting, onDelete }: NoteCardProps) {
+export function NoteCard({ note, onError }: NoteCardProps) {
+  const [togglePinned] = useWriter(note, (target) => target.togglePinned())
+  const [deleteForever, { isPending: isDeleting }] = useWriter(note, (target) =>
+    target.deleteForever(),
+  )
+
+  const reportError = (error: unknown) => {
+    onError?.(error instanceof Error ? error.message : String(error))
+  }
+
   return (
     <View style={[styles.card, note.pinned && styles.cardPinned]} testID={`note-card-${note.id}`}>
       <View style={styles.cardHeader}>
@@ -19,7 +28,7 @@ export function NoteCard({ note, isDeleting, onDelete }: NoteCardProps) {
         </Text>
         <View style={styles.cardActions}>
           <Pressable
-            onPress={() => void note.togglePinned()}
+            onPress={() => void togglePinned().catch(reportError)}
             hitSlop={12}
             style={styles.actionHit}
             testID={notePinTestID(note.title)}
@@ -32,7 +41,7 @@ export function NoteCard({ note, isDeleting, onDelete }: NoteCardProps) {
             </Text>
           </Pressable>
           <Pressable
-            onPress={() => onDelete(note)}
+            onPress={() => void deleteForever().catch(reportError)}
             disabled={isDeleting}
             hitSlop={12}
             style={styles.actionHit}

--- a/examples/NotesApp/src/components/NotesList.tsx
+++ b/examples/NotesApp/src/components/NotesList.tsx
@@ -10,12 +10,11 @@ export type { NotesListHandle } from './NotesListHandle'
 
 type NotesListProps = {
   notes: Note[]
-  deletingIds: ReadonlySet<string>
-  onDelete: (note: Note) => void
+  onError?: (message: string) => void
   ref?: Ref<NotesListHandle>
 }
 
-export function NotesList({ notes, deletingIds, onDelete, ref }: NotesListProps) {
+export function NotesList({ notes, onError, ref }: NotesListProps) {
   const listRef = useRef<FlashListRef<Note>>(null)
 
   useImperativeHandle(ref, () => ({
@@ -42,9 +41,7 @@ export function NotesList({ notes, deletingIds, onDelete, ref }: NotesListProps)
           No notes yet. Add one below.
         </Text>
       }
-      renderItem={({ item }) => (
-        <NoteCard note={item} isDeleting={deletingIds.has(item.id)} onDelete={onDelete} />
-      )}
+      renderItem={({ item }) => <NoteCard note={item} onError={onError} />}
     />
   )
 }

--- a/examples/NotesApp/src/components/NotesList.windows.tsx
+++ b/examples/NotesApp/src/components/NotesList.windows.tsx
@@ -9,12 +9,11 @@ export type { NotesListHandle } from './NotesListHandle'
 
 type NotesListProps = {
   notes: Note[]
-  deletingIds: ReadonlySet<string>
-  onDelete: (note: Note) => void
+  onError?: (message: string) => void
   ref?: Ref<NotesListHandle>
 }
 
-export function NotesList({ notes, deletingIds, onDelete, ref }: NotesListProps) {
+export function NotesList({ notes, onError, ref }: NotesListProps) {
   const listRef = useRef<ScrollView>(null)
 
   useImperativeHandle(ref, () => ({
@@ -44,14 +43,7 @@ export function NotesList({ notes, deletingIds, onDelete, ref }: NotesListProps)
             No notes yet. Add one below.
           </Text>
         ) : (
-          notes.map((note) => (
-            <NoteCard
-              key={note.id}
-              note={note}
-              isDeleting={deletingIds.has(note.id)}
-              onDelete={onDelete}
-            />
-          ))
+          notes.map((note) => <NoteCard key={note.id} note={note} onError={onError} />)
         )}
       </ScrollView>
     </View>

--- a/examples/NotesApp/src/hooks/useNotes.ts
+++ b/examples/NotesApp/src/hooks/useNotes.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { Q } from 'nitromelondb'
+import { useObservable, useQuery } from 'nitromelondb/hooks'
 import type { ExampleDatabase } from '../database'
 import type Note from '../model/Note'
 
@@ -12,43 +13,22 @@ export function useNotes(
   page: number,
   pageSize: number,
 ): { notes: Note[]; totalCount: number } {
-  const [notes, setNotes] = useState<Note[]>([])
-  const [totalCount, setTotalCount] = useState(0)
-
-  useEffect(() => {
-    let cancelled = false
-    const unsubscribeCount = session.notes.query().experimentalSubscribeToCount((count) => {
-      if (!cancelled) {
-        setTotalCount(count)
-      }
-    })
-
-    return () => {
-      cancelled = true
-      unsubscribeCount()
-    }
-  }, [session])
-
-  useEffect(() => {
-    let cancelled = false
-    const unsubscribe = session.notes
-      .query(
+  const listQuery = useMemo(
+    () =>
+      session.notes.query(
         Q.sortBy('pinned', Q.desc),
         Q.sortBy('rank', Q.asc),
         Q.skip((page - 1) * pageSize),
         Q.take(pageSize),
-      )
-      .experimentalSubscribeWithColumns(['title', 'body', 'pinned', 'rank'], (next) => {
-        if (!cancelled) {
-          setNotes(next)
-        }
-      })
+      ),
+    [session, page, pageSize],
+  )
+  // A separate, unpaginated query -- observeCount() only reports how many rows match, not which
+  // page they're on, so it doesn't need (or want) the skip/take above.
+  const countObservable = useMemo(() => session.notes.query().observeCount(), [session])
 
-    return () => {
-      cancelled = true
-      unsubscribe()
-    }
-  }, [session, page, pageSize])
+  const notes = useQuery(listQuery, ['title', 'body', 'pinned', 'rank'])
+  const [totalCount] = useObservable(countObservable, 0)
 
   return { notes, totalCount }
 }

--- a/examples/NotesApp/src/model/Note.ts
+++ b/examples/NotesApp/src/model/Note.ts
@@ -1,6 +1,6 @@
 import type { Collection } from 'nitromelondb'
 import { Model, Q } from 'nitromelondb'
-import { date, field, readonly, text, writer } from 'nitromelondb/decorators'
+import { date, field, readonly, text } from 'nitromelondb/decorators'
 import { NOTES_TABLE } from './schema'
 
 export default class Note extends Model {
@@ -49,14 +49,16 @@ export default class Note extends Model {
   @field('rank')
   rank!: number
 
-  @writer
+  // Not @writer: called via useWriter (see NoteCard), which already runs this
+  // inside a Writer -- an @writer method calling database.write() itself
+  // would nest writers and deadlock, since the outer write() can't resolve
+  // until the inner one does.
   async togglePinned() {
     await this.update((note) => {
       note.pinned = !note.pinned
     })
   }
 
-  @writer
   async deleteForever() {
     const notes = this.collections.get<Note>(NOTES_TABLE)
     const following = await notes.query(Q.where('rank', Q.gt(this.rank))).fetch()

--- a/examples/NotesApp/src/screens/NotesScreen.tsx
+++ b/examples/NotesApp/src/screens/NotesScreen.tsx
@@ -22,7 +22,6 @@ export function NotesScreen({ db }: NotesScreenProps) {
   const [body, setBody] = useState('')
   const [busy, setBusy] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
-  const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(() => new Set())
   // NotesComposer's Windows title field is uncontrolled (defaultValue) because
   // driver-injected/IME input there doesn't reliably fire onChangeText; bumping
   // this after a successful add remounts it to actually clear the text.
@@ -74,24 +73,6 @@ export function NotesScreen({ db }: NotesScreenProps) {
     }
   }
 
-  const deleteNote = async (note: Note) => {
-    if (deletingIds.has(note.id)) {
-      return
-    }
-    setDeletingIds((current) => new Set(current).add(note.id))
-    try {
-      await note.deleteForever()
-    } catch (writeError) {
-      setActionError(writeError instanceof Error ? writeError.message : String(writeError))
-    } finally {
-      setDeletingIds((current) => {
-        const next = new Set(current)
-        next.delete(note.id)
-        return next
-      })
-    }
-  }
-
   return (
     // Keyboard-avoidance is scoped to the composer (ComposerDock), not the
     // whole screen: an earlier root-level KeyboardAvoidingView ate Maestro's
@@ -113,12 +94,7 @@ export function NotesScreen({ db }: NotesScreenProps) {
         onNext={() => goToPage(1)}
       />
 
-      <NotesList
-        ref={listRef}
-        notes={notes}
-        deletingIds={deletingIds}
-        onDelete={(note) => void deleteNote(note)}
-      />
+      <NotesList ref={listRef} notes={notes} onError={setActionError} />
 
       <ComposerDock>
         <NotesComposer


### PR DESCRIPTION
## Summary
- `useNotes.ts`'s hand-rolled `useState`/`useEffect` pair (manual subscribe/unsubscribe, a `cancelled` flag guarding two separate subscriptions) is now `useQuery` for the paged notes and `useObservable(query.observeCount())` for the total, from the hooks added in #87.
- Pin/delete moved from a `NotesScreen`-level `deletingIds` `Set` threaded through `NotesList`/`NotesList.windows` as props into `NoteCard` itself, using `useWriter` for per-row `isPending`/`error` instead of hand-tracked state (`NotesScreen` no longer needs `deleteNote`/`deletingIds` at all — errors from either row action bubble up to the same `actionError` banner via an `onError` prop).
- `Note#togglePinned`/`deleteForever` drop `@writer`, since they're now invoked from inside `useWriter`'s own `database.write()` call — calling an already-`@writer`-decorated method from there would nest `write()` calls and deadlock (the outer write can't resolve until the inner one does, and the inner one is queued behind the outer).
- Net: 7 files, -43 lines, with two hand-rolled subscription effects and a `Set`-based per-row loading-lock removed.

## Test plan
- [x] `yarn typecheck` (library) — clean
- [x] `yarn test` (library) — 90 suites, 902 passed
- [x] `npx tsc --noEmit` in `examples/NotesApp` — clean
- [x] `npx prettier --check` on touched files — clean
- [ ] Manual device/Maestro verification — not run this session (Metro was already bound to the main checkout's copy of NotesApp on port 8081; avoided starting a second server or disrupting that session). Recommend a Maestro pass (`maestro test maestro/add-pin-delete.yaml` in particular, since it exercises pin+delete) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)