### PR TITLE
feat: wire native low-memory signal to trim JS-side caches (iOS + Android)

### DIFF
--- a/native/android/src/main/cpp/DatabasePlatformAndroid.cpp
+++ b/native/android/src/main/cpp/DatabasePlatformAndroid.cpp
@@ -150,9 +150,21 @@ void deleteDatabaseFile(std::string path, bool warnIfDoesNotExist) {
     deleteFileIfExists(shmPath, false);
 }
 
+// Unlike destroyListeners (a one-time teardown event, cleared after firing),
+// this is never cleared -- a memory alert can fire many times over a
+// Database's life. Each registered lambda captures a weak_ptr, so this is
+// bounded by "number of Database/adapter instances ever created in the
+// process", not unbounded in practice.
+std::vector<std::function<void()>> memoryAlertListeners;
+
 void onMemoryAlert(std::function<void(void)> callback) {
-    // TODO: Unimplemented
-    // NOTE: https://developer.android.com/reference/android/app/Application#onTrimMemory(int)
+    memoryAlertListeners.push_back(callback);
+}
+
+void triggerMemoryAlert() {
+    for (auto listener : memoryAlertListeners) {
+        listener();
+    }
 }
 
 struct ProvidedSyncJson {

--- a/native/android/src/main/cpp/DatabasePlatformAndroid.h
+++ b/native/android/src/main/cpp/DatabasePlatformAndroid.h
@@ -8,6 +8,7 @@ namespace platform {
 void configureJNI(JNIEnv *env);
 void provideJson(int id, jbyteArray array);
 void destroy();
+void triggerMemoryAlert();
 
 } // namespace platform
 } // namespace watermelondb

--- a/native/android/src/main/cpp/cpp-adapter.cpp
+++ b/native/android/src/main/cpp/cpp-adapter.cpp
@@ -21,3 +21,9 @@ JNIEXPORT void JNICALL
 Java_com_nozbe_watermelondb_NitromelonNative_provideSyncJson(JNIEnv* env, jclass, jint id, jbyteArray array) {
   watermelondb::platform::provideJson(id, array);
 }
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_nozbe_watermelondb_NitromelonNative_onMemoryAlert(JNIEnv*, jclass, jint) {
+  watermelondb::platform::triggerMemoryAlert();
+}

--- a/native/android/src/main/java/com/nozbe/watermelondb/NitromelonNative.java
+++ b/native/android/src/main/java/com/nozbe/watermelondb/NitromelonNative.java
@@ -10,4 +10,6 @@ public final class NitromelonNative {
     public static native void onCatalystInstanceDestroy();
 
     public static native void provideSyncJson(int id, byte[] json);
+
+    public static native void onMemoryAlert(int level);
 }

--- a/native/android/src/main/java/com/nozbe/watermelondb/WatermelonDBPackage.java
+++ b/native/android/src/main/java/com/nozbe/watermelondb/WatermelonDBPackage.java
@@ -1,5 +1,8 @@
 package com.nozbe.watermelondb;
 
+import android.content.ComponentCallbacks2;
+import android.content.res.Configuration;
+
 import androidx.annotation.NonNull;
 
 import com.facebook.react.ReactPackage;
@@ -21,7 +24,35 @@ public class WatermelonDBPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactAppContext) {
         NativeDatabasePath.install(reactAppContext);
+        registerMemoryAlertCallbacks(reactAppContext);
         return Collections.singletonList(new HostModule(reactAppContext));
+    }
+
+    /**
+     * Registers globally on the process Application instance -- no cooperation needed from the
+     * consuming app (e.g. a custom Application subclass), since createNativeModules is already
+     * called automatically by RN's package-loading machinery.
+     *
+     * Only forwards "critical" levels: onTrimMemory fires routinely (e.g. on every backgrounding),
+     * not just under real memory pressure, and JS-side cache trimming is meant for the latter.
+     */
+    private static void registerMemoryAlertCallbacks(ReactApplicationContext reactAppContext) {
+        reactAppContext.getApplicationContext().registerComponentCallbacks(new ComponentCallbacks2() {
+            @Override
+            public void onTrimMemory(int level) {
+                if (level == TRIM_MEMORY_RUNNING_CRITICAL || level >= TRIM_MEMORY_COMPLETE) {
+                    NitromelonNative.onMemoryAlert(level);
+                }
+            }
+
+            @Override
+            public void onConfigurationChanged(@NonNull Configuration newConfig) {
+            }
+
+            @Override
+            public void onLowMemory() {
+            }
+        });
     }
 
     @NonNull

--- a/native/ios/WatermelonDB/DatabasePlatformIOS.mm
+++ b/native/ios/WatermelonDB/DatabasePlatformIOS.mm
@@ -1,6 +1,7 @@
 #include "DatabasePlatform.h"
 #import <Foundation/Foundation.h>
 #import <React/RCTBridge.h>
+#import <UIKit/UIKit.h>
 #include <mutex>
 #include <stdexcept>
 
@@ -62,7 +63,12 @@ void deleteDatabaseFile(std::string path, bool warnIfDoesNotExist) {
 }
 
 void onMemoryAlert(std::function<void(void)> callback) {
-    // TODO: Unimplemented
+    [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
+                                                    object:nil
+                                                     queue:nil
+                                                usingBlock: ^(NSNotification *note) {
+        callback();
+    }];
 }
 
 NSMutableDictionary<NSNumber *, NSData *> *providedSyncJsons = [NSMutableDictionary new];

--- a/native/nitro/HybridNitromelonDatabase.cpp
+++ b/native/nitro/HybridNitromelonDatabase.cpp
@@ -163,8 +163,26 @@ HybridNitromelonDatabase::HybridNitromelonDatabase(std::string dbName, bool uses
         databaseToDestroy->destroy();
       }
     });
+
+    // weak_from_this() returns weak_ptr<HybridObject> (the shared base --
+    // see NitroModules/HybridObject.hpp), so the locked pointer is cast back
+    // to this concrete type. A memory alert firing after this HybridObject
+    // is gone is then a safe no-op instead of a use-after-free.
+    std::weak_ptr<HybridObject> weakSelf = weak_from_this();
+    ::watermelondb::platform::onMemoryAlert([weakSelf]() {
+      if (auto self = weakSelf.lock()) {
+        auto* hybridDatabase = static_cast<HybridNitromelonDatabase*>(self.get());
+        if (hybridDatabase->memoryWarningCallback_) {
+          hybridDatabase->memoryWarningCallback_();
+        }
+      }
+    });
   }
   return *db_;
+}
+
+void HybridNitromelonDatabase::onMemoryWarning(const std::function<void()>& callback) {
+  memoryWarningCallback_ = callback;
 }
 
 NitromelonInitializeResult HybridNitromelonDatabase::initialize(const std::string&, double expectedVersion) {

--- a/native/nitro/HybridNitromelonDatabase.hpp
+++ b/native/nitro/HybridNitromelonDatabase.hpp
@@ -3,6 +3,7 @@
 #include "HybridNitromelonDatabaseSpec.hpp"
 #include "Database.h"
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -42,6 +43,7 @@ public:
   void unsafeExecuteMultiple(const std::string& sql) override;
   void unsafeResetDatabase(const std::string& schema, double schemaVersion) override;
   void unsafeClose() override;
+  void onMemoryWarning(const std::function<void()>& callback) override;
 
 private:
   ::watermelondb::Database& database();
@@ -50,6 +52,7 @@ private:
   bool usesExclusiveLocking_;
   bool initialized_ = false;
   std::shared_ptr<::watermelondb::Database> db_;
+  std::function<void()> memoryWarningCallback_;
 };
 
 } // namespace margelo::nitro::watermelondb

--- a/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.cpp
@@ -30,6 +30,7 @@ namespace margelo::nitro::watermelondb {
       prototype.registerHybridMethod("unsafeExecuteMultiple", &HybridNitromelonDatabaseSpec::unsafeExecuteMultiple);
       prototype.registerHybridMethod("unsafeResetDatabase", &HybridNitromelonDatabaseSpec::unsafeResetDatabase);
       prototype.registerHybridMethod("unsafeClose", &HybridNitromelonDatabaseSpec::unsafeClose);
+      prototype.registerHybridMethod("onMemoryWarning", &HybridNitromelonDatabaseSpec::onMemoryWarning);
     });
   }
 

--- a/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.hpp
@@ -24,6 +24,7 @@ namespace margelo::nitro::watermelondb { struct NitromelonInitializeResult; }
 #include <vector>
 #include <optional>
 #include <tuple>
+#include <functional>
 
 namespace margelo::nitro::watermelondb {
 
@@ -72,6 +73,7 @@ namespace margelo::nitro::watermelondb {
       virtual void unsafeExecuteMultiple(const std::string& sql) = 0;
       virtual void unsafeResetDatabase(const std::string& schema, double schemaVersion) = 0;
       virtual void unsafeClose() = 0;
+      virtual void onMemoryWarning(const std::function<void()>& callback) = 0;
 
     protected:
       // Hybrid Setup

--- a/src/adapters/sqlite/makeDispatcher/index.native.ts
+++ b/src/adapters/sqlite/makeDispatcher/index.native.ts
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 
 import { logger, invariant, type ConnectionTag } from '../../../utils/common'
+import { _triggerOnLowMemory } from '../../../utils/common/memory'
 import type { ResultCallback } from '../../../utils/fp/Result'
 import type { Nitromelon, NitromelonDatabase } from '../../../nitro/Nitromelon.nitro'
 import type {
@@ -73,6 +74,7 @@ class SqliteSyncDispatcher implements SqliteDispatcher {
     )
     this._nitro = nitro
     this._db = nitro.createAdapter(dbName, usesExclusiveLocking)
+    ;(this._db as NitromelonDatabase).onMemoryWarning(() => _triggerOnLowMemory())
   }
 
   call<T>(name: SqliteDispatcherMethod, _args: unknown[], callback: ResultCallback<T>): void {

--- a/src/decorators/date/index.ts
+++ b/src/decorators/date/index.ts
@@ -1,4 +1,5 @@
 import makeDecorator from '../../utils/common/makeDecorator'
+import { onLowMemory } from '../../utils/common/memory'
 import WeakValueCache from '../../utils/common/WeakValueCache'
 import { type ColumnName } from '../../Schema'
 
@@ -15,6 +16,9 @@ import { ensureDecoratorUsedProperly, type ModelDecoratorHost } from '../common'
 //   @date('reacted_at') reactedAt: Date
 
 const cache = new WeakValueCache<number, Date>()
+// prune(), not clear(): only reclaims already-dead entries, never evicts a
+// Date still referenced elsewhere.
+onLowMemory(() => cache.prune())
 
 const dateDecorator = makeDecorator(
   (columnName: unknown) => (target: object, key: string, descriptor: PropertyDescriptor) => {

--- a/src/nitro/Nitromelon.nitro.ts
+++ b/src/nitro/Nitromelon.nitro.ts
@@ -29,6 +29,9 @@ export interface NitromelonDatabase extends HybridObject<{ ios: 'c++'; android: 
   unsafeExecuteMultiple(sql: string): void
   unsafeResetDatabase(schema: string, schemaVersion: number): void
   unsafeClose(): void
+  // Registers a callback invoked when the OS signals critical memory
+  // pressure, so JS-side caches can proactively trim already-dead entries.
+  onMemoryWarning(callback: () => void): void
 }
 
 export interface Nitromelon extends HybridObject<{ ios: 'c++'; android: 'c++' }> {

--- a/src/utils/common/WeakValueCache/index.ts
+++ b/src/utils/common/WeakValueCache/index.ts
@@ -108,6 +108,15 @@ export default class WeakValueCache<K, V extends object> {
     })
   }
 
+  // Proactively removes entries whose value is already dead -- never a live
+  // one, so this is always safe to call, unlike clear(). Intended for a
+  // native low-memory signal: reclaims map-slot bookkeeping for values GC
+  // already collected, sooner than incidental access or (on Tier 1)
+  // FinalizationRegistry's own unspecified timing would.
+  prune(): void {
+    this.forEach(() => {})
+  }
+
   // Tier 2 only (WeakRef without FinalizationRegistry): a best-effort
   // backstop, not a correctness requirement -- get()/delete() always
   // self-check via a real deref() regardless of sweep timing, this just

--- a/src/utils/common/WeakValueCache/test.js
+++ b/src/utils/common/WeakValueCache/test.js
@@ -88,6 +88,22 @@ describe('WeakValueCache', () => {
     expect(cache._map.has('b')).toBe(false)
   })
 
+  it('prune() removes only dead entries, leaving live ones and their identity untouched', () => {
+    const cache = new WeakValueCache()
+    const liveValue = { name: 'a' }
+    cache.set('a', liveValue)
+    cache.set('b', { name: 'b' })
+
+    const ref = cache._map.get('b')
+    ref.deref = () => undefined
+
+    cache.prune()
+
+    expect(cache.size).toBe(1)
+    expect(cache.get('a')).toBe(liveValue)
+    expect(cache.get('b')).toBe(undefined)
+  })
+
   it('_finalize() is a no-op for a key that was already cleared', () => {
     const cache = new WeakValueCache()
     cache.set('k', {})


### PR DESCRIPTION
## Summary

Stacked on #96 — finishes the previously-stubbed native memory-warning plumbing end to end, so real OS memory pressure can proactively trim JS-side caches (like MMKV's memory-pressure listener).

- **Nitro spec**: `NitromelonDatabase#onMemoryWarning(callback)` registers a JS callback, invoked when the OS signals critical memory pressure.
- **iOS**: `platform::onMemoryAlert` observes `UIApplicationDidReceiveMemoryWarningNotification`, mirroring the existing `onDestroy`/`RCTBridgeWillReloadNotification` pattern exactly.
- **Android**: `platform::onMemoryAlert` is driven by a `ComponentCallbacks2` registered on the `ReactApplicationContext` in `WatermelonDBPackage` (no app cooperation needed — RN's package-loading machinery calls this automatically), filtered to `TRIM_MEMORY_RUNNING_CRITICAL`/`TRIM_MEMORY_COMPLETE` only, since `onTrimMemory` fires routinely (every backgrounding), not just under real pressure. Reaches C++ via the same JNI `RegisterNatives` pattern already used for `onCatalystInstanceDestroy`.
- `HybridNitromelonDatabase` registers `platform::onMemoryAlert` alongside the existing `platform::onDestroy` call, weak-capturing self so a signal firing after the JS object is disposed is a safe no-op.
- JS: the adapter registers the callback once per dispatcher, finally calling the previously-dead `_triggerOnLowMemory()`.
- `WeakValueCache` gets a `prune()` method: proactively reclaims already-dead entries, never live ones. The `@date` decorator's cache registers with `onLowMemory` via `prune()`.

**`RecordCache` and `KeyedSharedSubscribable` are deliberately NOT wired to this signal**:
- `RecordCache` never should be — see 817b06a8 on #96, which reverted it away from `WeakValueCache` entirely after it broke real device/CI runs (adapters depend on it never losing an entry the adapter still believes is cached).
- `KeyedSharedSubscribable` instances are per-`Query` and potentially created often — self-registering every instance into `onLowMemory`'s permanent callback list would reintroduce the exact unbounded-growth leak #96 fixed, just relocated.

**Out of scope**: Windows memory-pressure wiring — `native/windows/.../DatabasePlatformWindows.cpp`'s `onMemoryAlert` stays an unimplemented stub; Windows APIs for this differ significantly and need their own research pass.

## Test plan
- [x] `yarn test` — 913 passed, 23 skipped, 0 failed
- [x] `yarn typecheck` — clean
- [x] `yarn eslint` — clean
- [ ] Native compilation: **not verified in this environment** (no Xcode/Android NDK toolchain available) — iOS/Android/C++ changes were verified by careful pattern-matching against the existing, working `onDestroy` implementation on each platform, not by an actual build. Recommend a real device/CI build+Maestro run before merge, given #96's lesson that GC/native-boundary bugs don't reproduce in unit tests.