### PR TITLE
fix: trigger docs redeploy after perf-publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
     name: Publish perf benchmark history
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -333,6 +334,10 @@ jobs:
           git -C ../benchmarks-branch add results/benchmarks.json
           git -C ../benchmarks-branch commit -m "chore: record perf benchmark for ${GITHUB_SHA:0:7}"
           git -C ../benchmarks-branch push origin benchmarks
+      - name: Trigger docs redeploy to pick up the new benchmark
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docs.yml --ref master
   windows:
     needs: [eslint, typescript, ci-check]
     # windows-2025 currently ships VS 2026 (v180 / MSVC v145), SDK 10.0.26100,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,11 @@ on:
       - 'scripts/rewrite-readme-docs-links.mjs'
       - 'scripts/replace-docs-path.mjs'
       - '.github/workflows/docs.yml'
+  # Triggered by perf-publish (.github/workflows/ci.yml) after it pushes a new
+  # benchmark record to the `benchmarks` branch -- that push doesn't touch any
+  # of the paths above (or even this branch), so it wouldn't otherwise cause
+  # the Performance page to pick up the new data.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,14 +50,14 @@ jobs:
         run: yarn build
         working-directory: docs-website
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs-website/build
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     needs: build
     permissions:
       pages: write


### PR DESCRIPTION
The Performance page (#98) wasn't going to update automatically: `docs.yml` only redeploys on pushes to `master` that touch specific paths (docs-website/**, README, etc), and a push to the separate `benchmarks` branch never matches that. Found this while checking why the page would show stale/empty data after merge.

Adds `workflow_dispatch` to `docs.yml` and has `perf-publish` call `gh workflow run docs.yml --ref master` right after pushing the new benchmark record, so the site picks up fresh data on every merge to master automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)