### PR TITLE
fix(docs): unblock Docusaurus deploy + enlarge performance charts

### DIFF
--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -25,6 +25,10 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0"
   },
+  "//resolutions": "webpackbar <7 passes name/color opts straight to webpack.ProgressPlugin, which webpack >=5.99 rejects with a schema error and breaks `docusaurus build`. v7 is what Docusaurus 3.10 ships; drop this on the next Docusaurus upgrade.",
+  "resolutions": {
+    "webpackbar": "7.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/docs-website/src/components/PerformanceCharts/MetricChart.js
+++ b/docs-website/src/components/PerformanceCharts/MetricChart.js
@@ -1,80 +1,182 @@
-import React, { useMemo } from 'react'
+import React, { useId, useMemo } from 'react'
 import styles from './styles.module.css'
 
-const WIDTH = 640
-const HEIGHT = 220
-const PADDING = { top: 16, right: 16, bottom: 12, left: 40 }
+// Rendered into a responsive container via viewBox; these are the internal
+// coordinate units, not pixels. Wide + short reads well for a time series.
+const WIDTH = 960
+const HEIGHT = 300
+const PADDING = { top: 24, right: 24, bottom: 40, left: 56 }
 
-function buildPath(points) {
-  return points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ')
+const dateFmt = new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' })
+
+function buildLinePath(points) {
+  return points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ')
 }
 
 function seriesFor(history, metric) {
   return history
-    .map((record, index) => {
+    .map((record) => {
       const value = record.android?.[metric]
-      return value == null ? null : { index, value, sha: record.sha ?? String(index) }
+      if (value == null) return null
+      const t = Date.parse(record.date)
+      return {
+        value,
+        time: Number.isNaN(t) ? null : t,
+        sha: record.sha ?? '',
+        prNumber: record.prNumber ?? null,
+      }
     })
     .filter(Boolean)
 }
 
+/** A tight [min, max] domain around the data with ~12% head/foot room, plus a few round tick values. */
+function niceScale(values) {
+  const dataMin = Math.min(...values)
+  const dataMax = Math.max(...values)
+  const span = dataMax - dataMin
+  const pad = span === 0 ? Math.max(1, Math.abs(dataMax) * 0.05) : span * 0.12
+  let min = dataMin - pad
+  let max = dataMax + pad
+  // These metrics are never negative -- don't waste vertical space below zero.
+  if (min < 0 && dataMin >= 0) min = 0
+
+  const ticks = []
+  const step = (max - min) / 4
+  for (let i = 0; i <= 4; i++) ticks.push(min + step * i)
+  // Enough decimals that adjacent ticks read as distinct values.
+  const decimals = step >= 10 ? 0 : step >= 1 ? 1 : step >= 0.1 ? 2 : 3
+  return { min, max, ticks, decimals }
+}
+
 /** One metric (e.g. "cpu"), Android only, plotted as a hand-rolled inline SVG line chart. */
 export function MetricChart({ history, metric, label, unit }) {
+  const gradientId = `perf-area-${useId().replace(/:/g, '')}`
   const points = useMemo(() => seriesFor(history, metric), [history, metric])
 
   if (points.length === 0) {
     return (
       <div className={styles.chartCard}>
-        <h3>{label}</h3>
+        <div className={styles.chartHead}>
+          <h3>{label}</h3>
+        </div>
         <p className={styles.empty}>No data yet.</p>
       </div>
     )
   }
 
   const values = points.map((p) => p.value)
-  const maxIndex = Math.max(history.length - 1, 1)
-  const minValue = Math.min(0, ...values)
-  const maxValue = Math.max(...values) * 1.1 || 1
-  const valueRange = maxValue - minValue || 1
+  const { min, max, ticks, decimals } = niceScale(values)
+  const valueRange = max - min || 1
+
+  // Fall back to evenly-spaced points when timestamps are missing/degenerate.
+  const times = points.map((p) => p.time)
+  const haveTime = times.every((t) => t != null)
+  const tMin = haveTime ? Math.min(...times) : 0
+  const tMax = haveTime ? Math.max(...times) : points.length - 1
+  const tRange = tMax - tMin || 1
 
   const plotWidth = WIDTH - PADDING.left - PADDING.right
   const plotHeight = HEIGHT - PADDING.top - PADDING.bottom
 
-  const scaleX = (index) => PADDING.left + (index / maxIndex) * plotWidth
-  const scaleY = (value) => PADDING.top + plotHeight - ((value - minValue) / valueRange) * plotHeight
+  const scaleX = (p, i) => PADDING.left + ((haveTime ? p.time - tMin : i) / tRange) * plotWidth
+  const scaleY = (value) => PADDING.top + plotHeight - ((value - min) / valueRange) * plotHeight
 
-  const plotted = points.map((p) => ({ ...p, x: scaleX(p.index), y: scaleY(p.value) }))
+  const plotted = points.map((p, i) => ({ ...p, x: scaleX(p, i), y: scaleY(p.value) }))
+  const linePath = buildLinePath(plotted)
+  const first = plotted[0]
+  const last = plotted[plotted.length - 1]
+  const areaPath = `${linePath} L ${last.x.toFixed(1)} ${(PADDING.top + plotHeight).toFixed(
+    1
+  )} L ${first.x.toFixed(1)} ${(PADDING.top + plotHeight).toFixed(1)} Z`
+
+  const latest = points[points.length - 1]
+  const previous = points.length > 1 ? points[points.length - 2] : null
+  const delta = previous ? latest.value - previous.value : null
+
+  const xLabelIndices = points.length <= 3 ? plotted.map((_, i) => i) : [0, Math.floor((plotted.length - 1) / 2), plotted.length - 1]
 
   return (
     <div className={styles.chartCard}>
-      <h3>
-        {label} <span className={styles.unit}>({unit})</span>
-      </h3>
-      <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} role="img" aria-label={`${label} over time`} className={styles.svg}>
-        <line
-          x1={PADDING.left}
-          y1={PADDING.top + plotHeight}
-          x2={WIDTH - PADDING.right}
-          y2={PADDING.top + plotHeight}
-          className={styles.axis}
-        />
-        <line
-          x1={PADDING.left}
-          y1={PADDING.top}
-          x2={PADDING.left}
-          y2={PADDING.top + plotHeight}
-          className={styles.axis}
-        />
-        <text x={PADDING.left - 6} y={PADDING.top + 4} textAnchor="end" className={styles.axisLabel}>
-          {Math.round(maxValue)}
-        </text>
-        <text x={PADDING.left - 6} y={PADDING.top + plotHeight} textAnchor="end" className={styles.axisLabel}>
-          {Math.round(minValue)}
-        </text>
-        <path d={buildPath(plotted)} className={styles.lineAndroid} fill="none" />
-        {plotted.map((p) => (
-          <circle key={p.sha} cx={p.x} cy={p.y} r={2.5} className={styles.dotAndroid}>
-            <title>{`${p.sha.slice(0, 7)} · ${p.value}${unit}`}</title>
+      <div className={styles.chartHead}>
+        <h3>
+          {label} <span className={styles.unit}>({unit})</span>
+        </h3>
+        <div className={styles.latest}>
+          <span className={styles.latestValue}>
+            {latest.value}
+            <span className={styles.latestUnit}>{unit}</span>
+          </span>
+          {delta != null && Math.abs(delta) >= 0.05 && (
+            <span className={styles.delta}>
+              {delta > 0 ? '▲' : '▼'} {Math.abs(delta).toFixed(1)} vs previous
+            </span>
+          )}
+        </div>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        role="img"
+        aria-label={`${label} over ${points.length} runs`}
+        className={styles.svg}
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--perf-chart-android)" stopOpacity="0.22" />
+            <stop offset="100%" stopColor="var(--perf-chart-android)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {ticks.map((tick) => {
+          const y = scaleY(tick)
+          return (
+            <g key={tick}>
+              <line
+                x1={PADDING.left}
+                y1={y}
+                x2={WIDTH - PADDING.right}
+                y2={y}
+                className={styles.gridline}
+              />
+              <text x={PADDING.left - 10} y={y + 4} textAnchor="end" className={styles.axisLabel}>
+                {tick.toFixed(decimals)}
+              </text>
+            </g>
+          )
+        })}
+
+        {xLabelIndices.map((i) => {
+          const p = plotted[i]
+          if (!p || p.time == null) return null
+          const anchor = i === 0 ? 'start' : i === plotted.length - 1 ? 'end' : 'middle'
+          return (
+            <text
+              key={`x-${i}`}
+              x={p.x}
+              y={PADDING.top + plotHeight + 24}
+              textAnchor={anchor}
+              className={styles.axisLabel}
+            >
+              {dateFmt.format(new Date(p.time))}
+            </text>
+          )
+        })}
+
+        <path d={areaPath} fill={`url(#${gradientId})`} stroke="none" />
+        <path d={linePath} className={styles.lineAndroid} fill="none" />
+
+        {plotted.map((p, i) => (
+          <circle key={`${p.sha}-${i}`} cx={p.x} cy={p.y} r={3.5} className={styles.dotAndroid}>
+            <title>
+              {[
+                p.time != null ? dateFmt.format(new Date(p.time)) : `run ${i + 1}`,
+                p.sha ? p.sha.slice(0, 7) : null,
+                p.prNumber ? `#${p.prNumber}` : null,
+                `${p.value}${unit}`,
+              ]
+                .filter(Boolean)
+                .join(' · ')}
+            </title>
           </circle>
         ))}
       </svg>

--- a/docs-website/src/components/PerformanceCharts/index.js
+++ b/docs-website/src/components/PerformanceCharts/index.js
@@ -48,12 +48,19 @@ export default function PerformanceCharts() {
     )
   }
 
+  const runs = history.filter((r) => r.android != null).length
+
   return (
-    <div className={styles.grid}>
-      <MetricChart history={history} metric="score" label="Flashlight score" unit="/100" />
-      <MetricChart history={history} metric="cpu" label="CPU usage" unit="%" />
-      <MetricChart history={history} metric="ram" label="RAM usage" unit="MB" />
-      <MetricChart history={history} metric="fps" label="FPS" unit="fps" />
-    </div>
+    <>
+      <p className={styles.caption}>
+        {runs} run{runs === 1 ? '' : 's'} recorded · hover a point for the commit, date, and exact value.
+      </p>
+      <div className={styles.grid}>
+        <MetricChart history={history} metric="score" label="Flashlight score" unit="/100" />
+        <MetricChart history={history} metric="cpu" label="CPU usage" unit="%" />
+        <MetricChart history={history} metric="ram" label="RAM usage" unit="MB" />
+        <MetricChart history={history} metric="fps" label="FPS" unit="fps" />
+      </div>
+    </>
   )
 }

--- a/docs-website/src/components/PerformanceCharts/styles.module.css
+++ b/docs-website/src/components/PerformanceCharts/styles.module.css
@@ -1,24 +1,62 @@
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
+  /* Two wide charts per row on desktop, one per row once it gets tight. */
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 460px), 1fr));
+  gap: 1.5rem;
   margin: 2rem 0;
 }
 
 .chartCard {
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
-  padding: 1rem 1.25rem;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem 1rem;
+  background: var(--ifm-background-surface-color);
 }
 
-.chartCard h3 {
-  margin-bottom: 0.5rem;
+.chartHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.chartHead h3 {
+  margin: 0;
+  font-size: 1.1rem;
 }
 
 .unit {
   font-weight: normal;
   color: var(--ifm-color-emphasis-600);
-  font-size: 0.85em;
+  font-size: 0.8em;
+}
+
+.latest {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.latestValue {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--perf-chart-android);
+  line-height: 1;
+}
+
+.latestUnit {
+  font-size: 0.7em;
+  font-weight: 600;
+  margin-left: 0.1em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.delta {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+  white-space: nowrap;
 }
 
 .svg {
@@ -27,26 +65,40 @@
   overflow: visible;
 }
 
-.axis {
-  stroke: var(--ifm-color-emphasis-400);
+.gridline {
+  stroke: var(--ifm-color-emphasis-200);
   stroke-width: 1;
 }
 
 .axisLabel {
   fill: var(--ifm-color-emphasis-600);
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .lineAndroid {
   stroke: var(--perf-chart-android);
-  stroke-width: 2;
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+  stroke-linecap: round;
 }
 
 .dotAndroid {
   fill: var(--perf-chart-android);
+  stroke: var(--ifm-background-surface-color);
+  stroke-width: 1.5;
+}
+
+.dotAndroid:hover {
+  r: 5;
 }
 
 .empty {
   color: var(--ifm-color-emphasis-600);
   font-style: italic;
+}
+
+.caption {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.9rem;
+  margin: 0.5rem 0 0;
 }

--- a/docs-website/yarn.lock
+++ b/docs-website/yarn.lock
@@ -3929,15 +3929,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "ansi-escapes@npm:4.3.2"
-  dependencies:
-    type-fest: "npm:^0.21.3"
-  checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
-  languageName: node
-  linkType: hard
-
 "ansi-html-community@npm:^0.0.8":
   version: 0.0.8
   resolution: "ansi-html-community@npm:0.0.8"
@@ -3961,7 +3952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
+"ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -3974,6 +3965,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"ansis@npm:^3.2.0":
+  version: 3.17.0
+  resolution: "ansis@npm:3.17.0"
+  checksum: 10c0/d8fa94ca7bb91e7e5f8a7d323756aa075facce07c5d02ca883673e128b2873d16f93e0dec782f98f1eeb1f2b3b4b7b60dcf0ad98fb442e75054fe857988cc5cb
   languageName: node
   linkType: hard
 
@@ -5695,13 +5693,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "escape-string-regexp@npm:1.0.5"
-  checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
-  languageName: node
-  linkType: hard
-
 "escape-string-regexp@npm:^4.0.0":
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
@@ -6006,15 +5997,6 @@ __metadata:
   dependencies:
     xml-js: "npm:^1.6.11"
   checksum: 10c0/c0849bde569da94493224525db00614fd1855a5d7c2e990f6e8637bd0298e85c3d329efe476cba77e711e438c3fb48af60cd5ef0c409da5bcd1f479790b0a372
-  languageName: node
-  linkType: hard
-
-"figures@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "figures@npm:3.2.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
   languageName: node
   linkType: hard
 
@@ -7636,15 +7618,6 @@ __metadata:
   version: 2.0.0
   resolution: "markdown-extensions@npm:2.0.0"
   checksum: 10c0/406139da2aa0d5ebad86195c8e8c02412f873c452b4c087ae7bc767af37956141be449998223bb379eea179b5fd38dfa610602b6f29c22ddab5d51e627a7e41d
-  languageName: node
-  linkType: hard
-
-"markdown-table@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "markdown-table@npm:2.0.0"
-  dependencies:
-    repeat-string: "npm:^1.0.0"
-  checksum: 10c0/f257e0781ea50eb946919df84bdee4ba61f983971b277a369ca7276f89740fd0e2749b9b187163a42df4c48682b71962d4007215ce3523480028f06c11ddc2e6
   languageName: node
   linkType: hard
 
@@ -10753,13 +10726,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"repeat-string@npm:^1.0.0":
-  version: 1.6.1
-  resolution: "repeat-string@npm:1.6.1"
-  checksum: 10c0/87fa21bfdb2fbdedc44b9a5b118b7c1239bdd2c2c1e42742ef9119b7d412a5137a1d23f1a83dc6bb686f4f27429ac6f542e3d923090b44181bafa41e8ac0174d
-  languageName: node
-  linkType: hard
-
 "require-from-string@npm:^2.0.2":
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
@@ -11480,7 +11446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
@@ -11768,13 +11734,6 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^0.21.3":
-  version: 0.21.3
-  resolution: "type-fest@npm:0.21.3"
-  checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
   languageName: node
   linkType: hard
 
@@ -12285,21 +12244,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpackbar@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "webpackbar@npm:6.0.1"
+"webpackbar@npm:7.0.0":
+  version: 7.0.0
+  resolution: "webpackbar@npm:7.0.0"
   dependencies:
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
+    ansis: "npm:^3.2.0"
     consola: "npm:^3.2.3"
-    figures: "npm:^3.2.0"
-    markdown-table: "npm:^2.0.0"
     pretty-time: "npm:^1.1.0"
     std-env: "npm:^3.7.0"
-    wrap-ansi: "npm:^7.0.0"
   peerDependencies:
+    "@rspack/core": "*"
     webpack: 3 || 4 || 5
-  checksum: 10c0/8dfa2c55f8122f729c7efd515a2b50fb752c0d0cb27ec2ecdbc70d90a86d5f69f466c9c5d01004f71b500dafba957ecd4413fca196a98cf99a39b705f98cae97
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
+  checksum: 10c0/03ed85edca12af824319dfcd0fe5c3a90b9e3c86400a604a55589abe0a66a682033e7de027e89aae03652b6fb8ca7fd2831d86829179304ea3121f807808f7c6
   languageName: node
   linkType: hard
 
@@ -12367,17 +12328,6 @@ __metadata:
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: 10c0/08f70cd97dd9a20aea280847a1fe8148e17cae7d231640e41eb26d2388697cbe65b67fd9e68715251c39b080c5ae4f76d71a9a69fa101d897273efdfb1b58bf7
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "wrap-ansi@npm:7.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Docs deployment

The **Deploy docs** workflow has been red since webpack 5.99 landed in the
dependency tree. `webpackbar@6` forwards its `name` / `color` options
straight to `webpack.ProgressPlugin`, and webpack >= 5.99 now schema-validates
that plugin's options and rejects unknown keys:

```
ValidationError: Invalid options object. Progress Plugin has been initialized
using an options object that does not match the API schema.
 - options has an unknown property 'name'.
```

Fix: pin `webpackbar` to `7.0.0` via `resolutions` — the same version
Docusaurus 3.10 ships. `yarn build` is green again locally. The pin can go
away on the next Docusaurus upgrade (a `//resolutions` note in package.json
says so).

## Performance charts

The charts on `/performance` were tiny and near-flat: the y-axis started at 0
even though every score sits around 94, so each line hugged the top of an
mostly-empty box, four to a row.

- Wider cards — 2 per row on desktop, 1 once it gets tight — and a taller plot area
- Axis fitted to the data (±12% padding) instead of a forced 0 baseline
- Horizontal gridlines + de-duplicated y labels, date labels on the x-axis
- Soft area fill, bigger hover targets showing date · commit · PR · value
- "Latest value" and delta-vs-previous badge in each card header

All colours are existing Infima / `--perf-chart-android` theme vars, so light
and dark both work.

### Follow-up (not in this PR)
Embedding flashlight's own generated HTML report would need the raw
`flashlight test` result JSON persisted per commit (today only the
score/cpu/ram/fps summary is kept on the `benchmarks` branch), and that report
shows a single run's iteration curves rather than history over time — it's a
complement to these trend charts, not a drop-in replacement. Happy to do it as
a separate change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)