### PR TITLE
fix: release-notes emptiness check never caught a genuinely empty changelog

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -189,9 +189,17 @@ jobs:
         run: |
           node scripts/prepare-changelog.mjs roll "${{ env.NEW_VERSION }}"
           node scripts/prepare-changelog.mjs extract "${{ env.NEW_VERSION }}" > /tmp/release_notes.md
-          if [ ! -s /tmp/release_notes.md ]; then
+          # `[ -s file ]` only checks byte size, and `extract` prints via
+          # `console.log()`, which always emits a trailing newline even for an
+          # empty string -- so a "no notes" result is a 1-byte file, `-s` sees
+          # it as non-empty, and this check never fires. Strip whitespace
+          # before testing, so a genuinely contentless result (nothing but
+          # blank lines) is actually caught instead of silently producing a
+          # release with an empty changelog section further down the line.
+          if [ -z "$(tr -d '[:space:]' < /tmp/release_notes.md)" ]; then
             echo "_No unreleased notes were recorded._" > /tmp/release_notes.md
             echo "NOTES_EMPTY=true" >> "$GITHUB_ENV"
+            echo "::warning::No CHANGELOG-Unreleased.md entries were found for v${{ env.NEW_VERSION }}. Contributors should add an entry to CHANGELOG-Unreleased.md in their PR -- see CONTRIBUTING or the file's own header comment. Review this release PR's changelog section before merging."
           else
             echo "NOTES_EMPTY=false" >> "$GITHUB_ENV"
           fi
@@ -275,4 +283,7 @@ jobs:
         run: |
           echo "🎉 Release PR prepared for v${{ env.NEW_VERSION }}"
           echo ""
+          if [ "${{ env.NOTES_EMPTY }}" = "true" ]; then
+            echo "⚠️ No CHANGELOG-Unreleased.md entries were found -- double-check that's actually correct before merging, not just that PRs forgot to update it." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
           echo "Review and merge the PR. Publishing (tag, GitHub Release, npm) runs automatically after merge."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,7 +105,12 @@ jobs:
           if ! node scripts/prepare-changelog.mjs extract "${{ env.NEW_VERSION }}" > /tmp/release_notes.md; then
             echo "See the changelog for details." > /tmp/release_notes.md
           fi
-          if [ ! -s /tmp/release_notes.md ]; then
+          # `-s` only checks byte size; `extract` prints via `console.log()`,
+          # which emits a trailing newline even for an empty string, so a
+          # "no notes" result is a 1-byte file that `-s` reports as non-empty
+          # -- this fallback never fired as a result (see the identical fix
+          # in prepare-release.yml). Strip whitespace before testing.
+          if [ -z "$(tr -d '[:space:]' < /tmp/release_notes.md)" ]; then
             echo "See the changelog for details." > /tmp/release_notes.md
           fi
 


### PR DESCRIPTION
## What broke

Both release workflows tested for "no CHANGELOG-Unreleased.md notes" with `[ ! -s file ]` — a raw byte-size check. `scripts/prepare-changelog.mjs extract` prints via `console.log()`, which always appends a trailing newline, even for an empty string. So a genuinely empty result is a 1-byte file, `-s` reports that as non-empty, and the fallback text (`_No unreleased notes were recorded._` / `See the changelog for details.`) never fires.

This is exactly what happened for `v0.30.1-alpha.0`: empty GitHub Release body, empty `CHANGELOG.md` section, empty release-PR body — silently, with no fallback message either. It was about to repeat identically for `v0.30.1-alpha.1` (PR #116, backfilled by hand). Neither release actually had empty content to report — #96/#97 and #115 both shipped real changes — the PRs that landed them just didn't add an entry to `CHANGELOG-Unreleased.md`, and the automation had no way to surface that gap.

Reproduced locally:
```
$ node -e "console.log('')" | wc -c
1
$ [ ! -s file ]   # with that 1-byte file → false (bug: treated as "has content")
$ [ -z "$(tr -d '[:space:]' < file)" ]   # → true (correct: genuinely empty)
```

## Fix

- `prepare-release.yml` and `publish-release.yml`: strip whitespace before testing for emptiness, so a 1-byte (or otherwise whitespace-only) result is actually caught.
- `prepare-release.yml`: the `NOTES_EMPTY` env var was already being set but never read anywhere — wired it into an `::warning::` annotation plus a note in the job summary, so a human preparing a release sees this loudly (not just a blank section that's easy to miss during PR review).

## Verification

- Both workflow files parse cleanly (`js-yaml` load, no syntax errors).
- Reproduced the exact bug and confirmed the fix locally (see above).
- Did not run the workflows themselves (`workflow_dispatch`-only / requires an actual release), so this hasn't been exercised end-to-end in CI — recommend a dry run (or watching the next real "Prepare Release" dispatch) before fully trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)