### PR TITLE
feat: log when memory-pressure trimming actually runs (MMKV-style)

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -13,3 +13,5 @@
 ### Changes
 
 ### Internal
+
+- Memory-pressure trimming (the WeakValueCache-based caches and the native `sqlite3_db_release_memory` call added in 0.30.1) now logs when it actually runs — `logger.debug` on the JS side (`[Memory] <cache>: pruned N dead entries (...)`, `[Memory] Low memory signal received, notifying N listener(s)`), native `consoleLog`/`Logger` on iOS/Android — mirroring MMKV's debug logging for its own memory-warning handler, so the mechanism's activity is actually visible instead of silent.

--- a/native/android/src/main/java/com/nitromelondb/WatermelonDBPackage.java
+++ b/native/android/src/main/java/com/nitromelondb/WatermelonDBPackage.java
@@ -41,6 +41,10 @@ public class WatermelonDBPackage implements ReactPackage {
             @Override
             public void onTrimMemory(int level) {
                 if (level == TRIM_MEMORY_RUNNING_CRITICAL || level >= TRIM_MEMORY_COMPLETE) {
+                    if (BuildConfig.DEBUG) {
+                        Logger.getLogger("NitromelonHost").info(
+                                "onTrimMemory(" + level + ") is critical, forwarding to native memory-pressure listeners");
+                    }
                     NitromelonNative.onMemoryAlert(level);
                 }
             }

--- a/native/nitro/HybridNitromelonDatabase.cpp
+++ b/native/nitro/HybridNitromelonDatabase.cpp
@@ -178,6 +178,7 @@ HybridNitromelonDatabase::HybridNitromelonDatabase(std::string dbName, bool uses
         if (!hybridDatabase) {
           return;
         }
+        consoleLog("Memory-pressure alert received: releasing SQLite memory and notifying JS-side caches");
         // Release SQLite's own internal memory (page cache, etc.) directly, in
         // addition to (not instead of) the JS-side WeakValueCache pruning the
         // callback below triggers -- see Database::releaseMemory() and

--- a/native/shared/Database.cpp
+++ b/native/shared/Database.cpp
@@ -73,6 +73,11 @@ void Database::releaseMemory() {
     if (isDestroyed_ || !db_) {
         return;
     }
+    // NOTE: sqlite3_db_release_memory's return value is a status code
+    // (SQLITE_OK) in this vendored build, not a byte count -- unlike some
+    // other memory-management APIs, it doesn't report how much it freed, so
+    // this log can only say the call was made, not its effect.
+    consoleLog("Releasing SQLite's internal memory (page cache, etc.) due to a memory-pressure signal");
     sqlite3_db_release_memory(db_->sqlite);
 }
 

--- a/src/decorators/date/index.ts
+++ b/src/decorators/date/index.ts
@@ -15,7 +15,7 @@ import { ensureDecoratorUsedProperly, type ModelDecoratorHost } from '../common'
 // Examples:
 //   @date('reacted_at') reactedAt: Date
 
-const cache = new WeakValueCache<number, Date>()
+const cache = new WeakValueCache<number, Date>('@date decorator cache')
 // prune(), not clear(): only reclaims already-dead entries, never evicts a
 // Date still referenced elsewhere.
 onLowMemory(() => cache.prune())

--- a/src/utils/common/WeakValueCache/index.ts
+++ b/src/utils/common/WeakValueCache/index.ts
@@ -19,6 +19,8 @@
 //   polyfilled without engine support, so this tier doesn't pretend to be
 //   weak -- it just doesn't regress.
 
+import logger from '../logger'
+
 const hasWeakRef = typeof WeakRef !== 'undefined'
 const hasFinalizationRegistry = typeof FinalizationRegistry !== 'undefined'
 
@@ -33,7 +35,14 @@ export default class WeakValueCache<K, V extends object> {
 
   _sweepTimer: ReturnType<typeof setInterval> | undefined
 
-  constructor() {
+  // Purely for prune()'s debug log (below) -- identifies which cache logged,
+  // since a bare "pruned N entries" is meaningless with several instances
+  // (KeyedSharedSubscribable, the @date cache, …) all responding to the same
+  // low-memory signal. Optional and unused otherwise.
+  _label: string
+
+  constructor(label: string = 'WeakValueCache') {
+    this._label = label
     if (hasWeakRef && hasFinalizationRegistry) {
       this._registry = new FinalizationRegistry(this._finalize)
     }
@@ -114,7 +123,13 @@ export default class WeakValueCache<K, V extends object> {
   // already collected, sooner than incidental access or (on Tier 1)
   // FinalizationRegistry's own unspecified timing would.
   prune(): void {
+    const before = this._map.size
     this.forEach(() => {})
+    const after = this._map.size
+    const pruned = before - after
+    logger.debug(
+      `[Memory] ${this._label}: pruned ${pruned} dead ${pruned === 1 ? 'entry' : 'entries'} (${after} remaining, ${before} before)`,
+    )
   }
 
   // Tier 2 only (WeakRef without FinalizationRegistry): a best-effort

--- a/src/utils/common/WeakValueCache/test.js
+++ b/src/utils/common/WeakValueCache/test.js
@@ -1,3 +1,4 @@
+import logger from '../logger'
 import WeakValueCache from './index'
 
 describe('WeakValueCache', () => {
@@ -102,6 +103,34 @@ describe('WeakValueCache', () => {
     expect(cache.size).toBe(1)
     expect(cache.get('a')).toBe(liveValue)
     expect(cache.get('b')).toBe(undefined)
+  })
+
+  it('prune() logs a debug line naming the cache label, and the pruned/remaining counts', () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {})
+    const cache = new WeakValueCache('MyCache')
+    cache.set('a', {})
+    cache.set('b', {})
+
+    const ref = cache._map.get('b')
+    ref.deref = () => undefined
+
+    cache.prune()
+
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('MyCache'))
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('pruned 1'))
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('1 remaining'))
+    debugSpy.mockRestore()
+  })
+
+  it('prune() logs even when nothing was dead, so the signal is visible either way', () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {})
+    const cache = new WeakValueCache()
+    cache.set('a', {})
+
+    cache.prune()
+
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('pruned 0'))
+    debugSpy.mockRestore()
   })
 
   it('_finalize() is a no-op for a key that was already cleared', () => {

--- a/src/utils/common/memory/index.ts
+++ b/src/utils/common/memory/index.ts
@@ -1,9 +1,14 @@
+import logger from '../logger'
+
 type Callback = () => void;
 const lowMemoryCallbacks: Callback[] = [];
 export function onLowMemory(callback: Callback): void {
   lowMemoryCallbacks.push(callback);
 }
-// TODO: Not currently hooked up to anything
+// Called from the native memory-pressure signal (iOS didReceiveMemoryWarning,
+// Android onTrimMemory filtered to critical levels) via each SQLite adapter's
+// onMemoryWarning callback -- see makeDispatcher/index.native.ts.
 export function _triggerOnLowMemory(): void {
+  logger.debug(`[Memory] Low memory signal received, notifying ${lowMemoryCallbacks.length} listener(s)`)
   lowMemoryCallbacks.forEach(callback => callback());
 }

--- a/src/utils/subscriptions/KeyedSharedSubscribable/index.ts
+++ b/src/utils/subscriptions/KeyedSharedSubscribable/index.ts
@@ -37,7 +37,9 @@ export type Source<Value> = (subscriber: Subscriber<Value>) => Unsubscribe
  * ```
  */
 export default class KeyedSharedSubscribable<Key, Value> {
-  _subscribables: WeakValueCache<string, SharedSubscribable<Value>> = new WeakValueCache()
+  _subscribables: WeakValueCache<string, SharedSubscribable<Value>> = new WeakValueCache(
+    'KeyedSharedSubscribable',
+  )
 
   _keyOf: (key: Key) => string
 


### PR DESCRIPTION
## Why

The native low-memory signal and WeakValueCache-based cache pruning it triggers (#96, #115) ran completely silently — no way to confirm the mechanism is actually firing on a real device, or how much it's doing when it does. MMKV logs its own memory-warning handling; this adds the equivalent here.

## What

- `WeakValueCache` gets an optional constructor `label` (defaults to `'WeakValueCache'`), used by a new `prune()` debug log: `[Memory] <label>: pruned N dead entries (M remaining, K before)`. Logs unconditionally — even 0 pruned — so the signal reaching a cache is visible either way, not just when it found something to do. The `@date` decorator's cache and `KeyedSharedSubscribable`'s `_subscribables` now pass real labels.
- `_triggerOnLowMemory()` logs how many `onLowMemory()` listeners it's about to notify. Also fixed the stale `// TODO: Not currently hooked up to anything` comment — it's been wired up since #96/#115.
- `HybridNitromelonDatabase`'s native memory-alert lambda (shared by iOS and Android) logs on receipt, before releasing SQLite's own memory and notifying JS.
- `Database::releaseMemory()` logs right before calling `sqlite3_db_release_memory`. Checked `native/vendor/sqlite/sqlite3.c` directly: this vendored build's implementation returns a status code (`SQLITE_OK`), not a byte count, so the log only confirms the call happened — it doesn't (and can't accurately) report bytes freed.
- Android's `onTrimMemory` logs the actual trim level it forwarded — the one place that info exists — gated behind `BuildConfig.DEBUG` via the same `java.util.logging.Logger("NitromelonHost")` pattern `notifyDestroy()` already uses in that file.

All logging is at debug level (JS `logger.debug`, native `consoleLog`, gated Android `Logger.info`) — the same low-noise tier this codebase already uses elsewhere (`Database#batch`'s `debugInfo` log), not print-by-default.

## Testing

- Two new `WeakValueCache` tests: the label appears in the log, and it logs even when nothing was pruned.
- `yarn test` (915 passed), `yarn typecheck`, `yarn eslint` — all clean.
- Native (iOS/Android/Windows) portions not build-verified in this environment (no Xcode/Android SDK/NDK) — pattern-matched against this file's own existing logging conventions (`consoleLog`, `Logger.getLogger("NitromelonHost")`), not compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)