### PR TITLE
fix(deps): remove expect@24 dev subtree via in-repo shim (#190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,5 +191,8 @@
     "semver": "^7.8.5",
     "typescript": "^6.0.3"
   },
+  "resolutions": {
+    "ansi-regex@^4.0.0": "4.1.1"
+  },
   "packageManager": "yarn@4.18.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,14 +3727,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "ansi-regex@npm:4.1.0"
-  checksum: 10c0/a10376bc12035b0b40f036d3e544d92f9e6a525bc7cd65f71e108c0965d74f777e0eef47a6d0bfbdec1d835df1edf0410516a39525d2d89ce9547eb47644d681
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^4.1.0":
+"ansi-regex@npm:4.1.1, ansi-regex@npm:^4.1.0":
   version: 4.1.1
   resolution: "ansi-regex@npm:4.1.1"
   checksum: 10c0/d36d34234d077e8770169d980fed7b2f3724bfa2a01da150ccd75ef9707c80e883d27cdf7a0eac2f145ac1d10a785a8a855cffd05b85f778629a0db62e7033da


### PR DESCRIPTION
> Approach under revision — see thread. Switching from a `resolutions` pin to an
> in-repo `expect` shim so the library carries no `resolutions` field and the
> ancient `expect@24` dev subtree is removed entirely.

## Goal

Close Dependabot alert #190 — `ansi-regex` ReDoS (CVE-2021-3807 / GHSA-93q8-gq69-wqmw, High).

## Root cause

`package.json` aliases `@nozbe/watermelondb_expect` to `expect@24.1.0` (2019), used
only by `src/__tests__/setUpIntegrationTestEnv.js` to provide `global.expect` for the
React Native integration-test bundle (`examples/NotesApp_windows`). That drags in
`jest-matcher-utils@24 -> jest-diff@24 -> pretty-format@24 -> ansi-regex@4.1.0`.

Never shipped to npm consumers — the build (`scripts/source-files.mjs`
`DO_NOT_BUILD_PATHS`) excludes everything under `__tests__/`.

## Plan

- Replace the `expect@24` alias with a small in-repo shim under `src/__tests__/`
  (auto-excluded from the npm tarball).
- Remove `@nozbe/watermelondb_expect` from `package.json` and
  `examples/NotesApp_windows/{package.json,metro.config.js}`.
- No `resolutions` added to the library.

Generated with Claude Code.
