### PR TITLE
fix(web): narrow Metro __tests__ blockList + verify vendored wa-sqlite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
         with:
           node-version: 24.x
       - run: yarn install --immutable
+      - name: Verify vendored wa-sqlite matches upstream + the documented patch
+        run: node scripts/vendor-wa-sqlite.mjs --verify
       - name: Install NotesApp
         working-directory: examples/NotesApp
         run: yarn install --immutable

--- a/examples/NotesApp/metro.config.js
+++ b/examples/NotesApp/metro.config.js
@@ -8,11 +8,30 @@ const workspaceRoot = path.resolve(projectRoot, '../..')
 const config = getDefaultConfig(projectRoot)
 
 // The web conformance screen intentionally imports NitromelonDB's shared
-// adapter cases. Expo excludes __tests__ by default, so make those sources
-// visible to this example's test bundle.
-config.resolver.blockList = config.resolver.blockList.filter(
-  (pattern) => !String(pattern).includes('__tests__'),
-)
+// adapter cases from `src/adapters/__tests__` (and their transitive `__tests__`
+// imports elsewhere under the library's `src/`). Expo's default blockList
+// excludes every `__tests__` directory, plus `.expo/types` and `.expo/web/cache`,
+// in one combined pattern. Dropping that whole pattern also unblocks `__tests__`
+// inside every installed package and drops the `.expo/*` exclusions as collateral.
+// Instead, keep blocking `__tests__` under `node_modules` (where Expo's default is
+// genuinely useful, e.g. broken fixtures or huge snapshots in a dependency's own
+// test folder) and keep the `.expo/*` exclusions, while leaving this workspace's
+// own `src/` alone. `nitromelondb`'s `src/` is resolved directly via
+// `extraNodeModules`/`watchFolders` below, never through a real
+// `node_modules/nitromelondb` path, so anchoring on `node_modules` targets
+// third-party packages precisely. This stays a positive match rather than a
+// `src/`-relative negative lookahead: Metro can hand combined blockList patterns
+// to Watchman's regex engine, which does not reliably support lookahead, and a
+// pattern Watchman mishandles fails silently by excluding files from the crawl.
+config.resolver.blockList = config.resolver.blockList.flatMap((pattern) => {
+  if (!String(pattern).includes('__tests__')) {
+    return [pattern]
+  }
+  return [
+    /[\\/]\.expo[\\/](?:types|web[\\/]cache)$/,
+    /[\\/]node_modules[\\/].*[\\/]__tests__[\\/].*$/,
+  ]
+})
 
 function resolveDep(name) {
   const local = path.resolve(projectRoot, 'node_modules', name)

--- a/scripts/vendor-wa-sqlite.mjs
+++ b/scripts/vendor-wa-sqlite.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Vendor wa-sqlite's Asyncify build into src/adapters/sqlite/sqlite-wasm.
+ *
+ * Unlike native/vendor/sqlite and native/vendor/simdjson, wa-sqlite is not
+ * published to npm, so this pulls the prebuilt `dist/wa-sqlite-async.{mjs,wasm}`
+ * artifacts directly from a pinned commit of github.com/rhashimoto/wa-sqlite
+ * and reapplies the one documented source patch (see VENDOR.md).
+ *
+ *   node scripts/vendor-wa-sqlite.mjs <commit-sha> [tag]   # bump to a new commit
+ *   node scripts/vendor-wa-sqlite.mjs --verify              # check committed files match VENDOR.md and upstream
+ */
+import { createHash } from 'crypto'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const VENDOR_DIR = path.join(ROOT, 'src', 'adapters', 'sqlite', 'sqlite-wasm')
+const MJS_NAME = 'wa-sqlite-async.mjs'
+const WASM_NAME = 'wa-sqlite-async.wasm'
+const VENDOR_MD_PATH = path.join(VENDOR_DIR, 'VENDOR.md')
+const REPO = 'rhashimoto/wa-sqlite'
+
+// The single deliberate source patch, documented in VENDOR.md: Expo Metro
+// rewrites `import.meta` to `undefined` in worker chunks, which would crash
+// this module-top-level assignment. This build is worker-only, so
+// `self.location.href` is an equivalent, safe base.
+const PATCH_MARKER = '  var _scriptName = import.meta.url;'
+const PATCH_REPLACEMENT = [
+  '  // Expo Metro worker chunks currently rewrite import.meta to undefined.',
+  '  // This build is worker-only, so the worker script URL is the equivalent base.',
+  '  var _scriptName = self.location.href;',
+].join('\n')
+
+function usage() {
+  console.error('Usage: node scripts/vendor-wa-sqlite.mjs <commit-sha> [tag] | --verify')
+  process.exit(2)
+}
+
+const args = process.argv.slice(2)
+const verifyMode = args.includes('--verify')
+const positionals = args.filter((arg) => !arg.startsWith('--'))
+const commitArg = positionals[0]
+const tagArg = positionals[1]
+
+if (!verifyMode && !commitArg) {
+  usage()
+}
+if (commitArg && !/^[0-9a-f]{40}$/.test(commitArg)) {
+  console.error(`Pass a full 40-character commit sha, got: ${commitArg}`)
+  process.exit(2)
+}
+
+function sha256(buffer) {
+  return createHash('sha256').update(buffer).digest('hex')
+}
+
+// Runs in CI on every push, so tolerate a transient raw.githubusercontent.com blip.
+async function fetchWithRetry(url, attempts = 3) {
+  let lastError
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        headers: { 'User-Agent': 'NitromelonDB-vendor-wa-sqlite' },
+      })
+      if (!response.ok) {
+        throw new Error(`${url} -> ${response.status} ${response.statusText}`)
+      }
+      return response
+    } catch (error) {
+      lastError = error
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000))
+      }
+    }
+  }
+  throw lastError
+}
+
+async function fetchText(url) {
+  return (await fetchWithRetry(url)).text()
+}
+
+async function fetchBuffer(url) {
+  return Buffer.from(await (await fetchWithRetry(url)).arrayBuffer())
+}
+
+function applyPatch(upstreamSource) {
+  const occurrences = upstreamSource.split(PATCH_MARKER).length - 1
+  if (occurrences !== 1) {
+    throw new Error(
+      `Expected exactly one "${PATCH_MARKER.trim()}" line in upstream wa-sqlite-async.mjs, ` +
+        `found ${occurrences}. Upstream's Emscripten output shape has changed; update ` +
+        'PATCH_MARKER/PATCH_REPLACEMENT in this script before vendoring.',
+    )
+  }
+  return upstreamSource.replace(PATCH_MARKER, PATCH_REPLACEMENT)
+}
+
+/** Download + patch the artifacts for one commit. Does not touch the filesystem. */
+async function buildArtifacts(commit, tag) {
+  const base = `https://raw.githubusercontent.com/${REPO}/${commit}/dist`
+  console.log(`Fetching wa-sqlite artifacts from ${base} ...`)
+  const [upstreamMjs, wasm] = await Promise.all([
+    fetchText(`${base}/${MJS_NAME}`),
+    fetchBuffer(`${base}/${WASM_NAME}`),
+  ])
+  const patchedMjs = applyPatch(upstreamMjs)
+  return {
+    commit,
+    tag,
+    wasm,
+    patchedMjs,
+    upstreamMjsHash: sha256(Buffer.from(upstreamMjs)),
+    patchedMjsHash: sha256(Buffer.from(patchedMjs)),
+    wasmHash: sha256(wasm),
+  }
+}
+
+function vendorMdContent({ commit, tag, wasmHash, patchedMjsHash, upstreamMjsHash }) {
+  const source = tag ? `tag \`${tag}\` (commit \`${commit}\`)` : `commit \`${commit}\``
+  return `# wa-sqlite binary provenance
+
+The Emscripten artifacts in this directory come from rhashimoto/wa-sqlite ${source}.
+The runtime JavaScript dependency in \`package.json\` is pinned to that same
+immutable commit.
+
+| File | SHA-256 |
+| --- | --- |
+| \`${WASM_NAME}\` | \`${wasmHash}\` |
+| \`${MJS_NAME}\` (patched) | \`${patchedMjsHash}\` |
+| upstream \`dist/${MJS_NAME}\` | \`${upstreamMjsHash}\` |
+
+The JavaScript glue has one deliberate source patch: its \`_scriptName\` base is
+\`self.location.href\` instead of \`import.meta.url\`. Expo Metro currently rewrites
+\`import.meta\` in the emitted worker chunk. This adapter is worker-only and also
+supplies \`wasmBinary\` and \`locateFile\`, so the worker URL is the correct safe base.
+
+Regenerate both artifacts and this file with:
+
+\`\`\`
+node scripts/vendor-wa-sqlite.mjs <commit-sha>
+\`\`\`
+
+CI runs \`node scripts/vendor-wa-sqlite.mjs --verify\` on every push to confirm the
+committed artifacts still equal upstream plus exactly that one patch, and that this
+file's hashes match. When bumping to a new commit, also update the pinned commit in
+\`package.json\`'s \`wa-sqlite\` dependency (\`.yarnrc.yml\`'s \`approvedGitRepositories\`
+entry for rhashimoto/wa-sqlite does not need to change), then run the Chromium suite
+(\`yarn --cwd examples/NotesApp test:web\`).
+`
+}
+
+function readCommittedVendorMd() {
+  const text = fs.readFileSync(VENDOR_MD_PATH, 'utf8')
+  const commitMatch = text.match(/commit `([0-9a-f]{40})`/)
+  if (!commitMatch) {
+    throw new Error(`Could not find a pinned commit sha in ${VENDOR_MD_PATH}`)
+  }
+
+  // Table rows look like `| `name` (suffix) | `hash` |` — pull every
+  // backtick-quoted token per line rather than assuming a fixed shape, since
+  // the name column carries free text like "(patched)".
+  const rows = text
+    .split('\n')
+    .map((line) => [...line.matchAll(/`([^`]+)`/g)].map((match) => match[1]))
+    .filter((tokens) => tokens.length === 2 && /^[0-9a-f]{64}$/.test(tokens[1]))
+
+  const hashFor = (predicate) => rows.find(([name]) => predicate(name))?.[1]
+
+  return {
+    commit: commitMatch[1],
+    wasmHash: hashFor((name) => name.includes(WASM_NAME)),
+    patchedMjsHash: hashFor((name) => name.includes(MJS_NAME) && !name.includes('dist/')),
+    upstreamMjsHash: hashFor((name) => name.includes(`dist/${MJS_NAME}`)),
+  }
+}
+
+async function verify() {
+  const documented = readCommittedVendorMd()
+  const committedWasm = fs.readFileSync(path.join(VENDOR_DIR, WASM_NAME))
+  const committedMjs = fs.readFileSync(path.join(VENDOR_DIR, MJS_NAME), 'utf8')
+  const committedWasmHash = sha256(committedWasm)
+  const committedMjsHash = sha256(Buffer.from(committedMjs))
+
+  const problems = []
+  if (committedWasmHash !== documented.wasmHash) {
+    problems.push(
+      `${WASM_NAME} hash ${committedWasmHash} does not match VENDOR.md (${documented.wasmHash})`,
+    )
+  }
+  if (committedMjsHash !== documented.patchedMjsHash) {
+    problems.push(
+      `${MJS_NAME} hash ${committedMjsHash} does not match VENDOR.md (${documented.patchedMjsHash})`,
+    )
+  }
+
+  const fresh = await buildArtifacts(documented.commit)
+  if (fresh.wasmHash !== documented.wasmHash) {
+    problems.push(
+      `Re-downloading ${WASM_NAME} from commit ${documented.commit} gives hash ` +
+        `${fresh.wasmHash}, but VENDOR.md says ${documented.wasmHash}. ` +
+        'The upstream artifact at this commit no longer matches what was vendored.',
+    )
+  }
+  if (fresh.patchedMjsHash !== documented.patchedMjsHash) {
+    problems.push(
+      `Re-downloading and re-patching ${MJS_NAME} from commit ${documented.commit} gives ` +
+        `hash ${fresh.patchedMjsHash}, but VENDOR.md says ${documented.patchedMjsHash}. ` +
+        'Either upstream changed, or the committed file no longer equals ' +
+        'upstream + exactly the documented patch.',
+    )
+  }
+  if (fresh.upstreamMjsHash !== documented.upstreamMjsHash) {
+    problems.push(
+      `Upstream ${MJS_NAME} at commit ${documented.commit} now hashes to ` +
+        `${fresh.upstreamMjsHash}, but VENDOR.md says ${documented.upstreamMjsHash}.`,
+    )
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
+  const pinnedDep = packageJson.dependencies?.['wa-sqlite'] ?? ''
+  if (!pinnedDep.includes(documented.commit)) {
+    problems.push(
+      `package.json's "wa-sqlite" dependency (${pinnedDep || '<missing>'}) does not ` +
+        `reference the commit documented in VENDOR.md (${documented.commit}).`,
+    )
+  }
+
+  if (problems.length) {
+    console.error('wa-sqlite vendor verification failed:\n')
+    problems.forEach((problem) => console.error(`  - ${problem}`))
+    console.error('\nRun `node scripts/vendor-wa-sqlite.mjs <commit-sha>` to regenerate.')
+    process.exit(1)
+  }
+
+  console.log(
+    `OK: ${MJS_NAME} and ${WASM_NAME} match upstream commit ${documented.commit} ` +
+      'plus exactly the documented patch, and VENDOR.md / package.json agree.',
+  )
+}
+
+async function bump(commit, tag) {
+  const artifacts = await buildArtifacts(commit, tag)
+  fs.writeFileSync(path.join(VENDOR_DIR, MJS_NAME), artifacts.patchedMjs)
+  fs.writeFileSync(path.join(VENDOR_DIR, WASM_NAME), artifacts.wasm)
+  fs.writeFileSync(VENDOR_MD_PATH, vendorMdContent(artifacts))
+  console.log(`Vendored wa-sqlite from commit ${commit} into ${path.relative(ROOT, VENDOR_DIR)}`)
+  console.log('Update the pinned commit in package.json\'s "wa-sqlite" dependency to match,')
+  console.log('then run `yarn --cwd examples/NotesApp test:web` before committing.')
+}
+
+if (verifyMode) {
+  await verify()
+} else {
+  await bump(commitArg, tagArg)
+}

--- a/src/adapters/sqlite/sqlite-wasm/VENDOR.md
+++ b/src/adapters/sqlite/sqlite-wasm/VENDOR.md
@@ -1,8 +1,8 @@
 # wa-sqlite binary provenance
 
-The Emscripten artifacts in this directory come from rhashimoto/wa-sqlite
-tag `v1.1.2`, commit `2bf1c59d89eb6497535a4217bc62fec68a0bb994`.
-The runtime JavaScript dependency is pinned to that immutable commit too.
+The Emscripten artifacts in this directory come from rhashimoto/wa-sqlite tag `v1.1.2` (commit `2bf1c59d89eb6497535a4217bc62fec68a0bb994`).
+The runtime JavaScript dependency in `package.json` is pinned to that same
+immutable commit.
 
 | File | SHA-256 |
 | --- | --- |
@@ -15,7 +15,15 @@ The JavaScript glue has one deliberate source patch: its `_scriptName` base is
 `import.meta` in the emitted worker chunk. This adapter is worker-only and also
 supplies `wasmBinary` and `locateFile`, so the worker URL is the correct safe base.
 
-The intended follow-up is a `scripts/vendor-wa-sqlite.mjs` updater and scheduled
-workflow, matching the existing SQLite and simdjson vendor automation. Until
-then, updates must copy both upstream artifacts from the same commit, reapply
-the single patch above, update all three hashes, and run the Chromium suite.
+Regenerate both artifacts and this file with:
+
+```
+node scripts/vendor-wa-sqlite.mjs <commit-sha>
+```
+
+CI runs `node scripts/vendor-wa-sqlite.mjs --verify` on every push to confirm the
+committed artifacts still equal upstream plus exactly that one patch, and that this
+file's hashes match. When bumping to a new commit, also update the pinned commit in
+`package.json`'s `wa-sqlite` dependency (`.yarnrc.yml`'s `approvedGitRepositories`
+entry for rhashimoto/wa-sqlite does not need to change), then run the Chromium suite
+(`yarn --cwd examples/NotesApp test:web`).


### PR DESCRIPTION
Follow-ups to #119 that we flagged in review but didn't get folded in before merge. Two independent changes.

## 1. Narrow the Metro `__tests__` blockList (`examples/NotesApp/metro.config.js`)

The web conformance screen imports the shared adapter test cases from `src/adapters/__tests__`, and #119 made those reachable by dropping Expo's entire default blockList pattern:

```js
config.resolver.blockList = config.resolver.blockList.filter(
  (pattern) => !String(pattern).includes('__tests__'),
)
```

That one pattern also covers `.expo/types` and `.expo/web/cache`, and it applied to every platform, so this unblocked `__tests__` directories inside every installed package and dropped the `.expo/*` exclusions as a side effect.

This replaces it with a pair that keeps blocking `__tests__` **under `node_modules`** (where Expo's default is genuinely useful) and keeps the `.expo/*` exclusions, while leaving the library's own `src/` alone. `nitromelondb`'s `src/` resolves directly via `extraNodeModules`/`watchFolders`, never through a real `node_modules/nitromelondb` path, so anchoring on `node_modules` is precise.

Kept as a positive match rather than a `src/`-relative negative lookahead on purpose: Metro can hand combined blockList patterns to Watchman, whose regex engine doesn't reliably support lookahead, and a mishandled pattern fails silently by dropping files from the crawl.

Verified with a clean Metro cache that `yarn --cwd examples/NotesApp test:web` still exports the `WebAdapterTestScreen` chunk and passes the full Chromium adapter + migration suite, and that `node_modules/**/__tests__` plus `.expo/types` / `.expo/web/cache` stay blocked.

## 2. Verify the vendored wa-sqlite blobs in CI (`scripts/vendor-wa-sqlite.mjs`)

Nothing checked that the committed `wa-sqlite-async.mjs` / `.wasm` still matched the hashes in `VENDOR.md`, so a hand edit to the minified glue or the binary would have gone unnoticed. `VENDOR.md` also still called the vendor script an "intended follow-up".

New `scripts/vendor-wa-sqlite.mjs`, same shape as `vendor-sqlite.mjs` / `vendor-simdjson.mjs`:

- `node scripts/vendor-wa-sqlite.mjs <commit-sha> [tag]` re-downloads `dist/wa-sqlite-async.{mjs,wasm}` from that commit of `rhashimoto/wa-sqlite`, reapplies the one documented source patch (`_scriptName = self.location.href` instead of `import.meta.url`) via an exact string replace that errors loudly if upstream's Emscripten output no longer contains that line, and rewrites `VENDOR.md`.
- `node scripts/vendor-wa-sqlite.mjs --verify` re-derives everything from a fresh download of the commit `VENDOR.md` documents and fails with a specific message if the committed `.mjs`, the committed `.wasm`, upstream itself, or `package.json`'s pinned commit have drifted.

`--verify` is wired into the `notesapp-web` CI job. The fetch has a small retry so a transient `raw.githubusercontent.com` blip doesn't fail CI.

Verified `--verify` passes against the currently vendored artifacts, fails clearly when either file is tampered with, and that re-running the bump against the same pinned commit reproduces the committed `.mjs` / `.wasm` byte-for-byte (only `VENDOR.md` prose changes).

A scheduled vendor-bump workflow like `sqlite.yml` / `simdjson.yml` is still a reasonable follow-up. This just closes the gap that nothing was verifying the two committed blobs at all. Fully vendoring wa-sqlite so consumers don't need git/GitHub at install time is also still worthwhile, separately.
