### PR TITLE
fix(docs): repair the broken wa-sqlite guide link that's failing Deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const adapter = new SQLiteAdapter({
 `usesExclusiveLocking: true` is rejected on web because the IndexedDB VFS supports multiple connections and tabs. Web initialization is deferred until hydration, so importing and constructing an adapter during SSR is safe; attempts to query it on the server fail with a message directing server code to its authoritative database. Existing LokiJS browser data is not migrated.
 
 Architecture, offline and multi-tab behavior, sync JSON, known issues, testing, and future work are
-documented in the [wa-sqlite web adapter guide](docs-website/docs/docs/Implementation/WaSQLiteAdapter.md).
+documented in the [wa-sqlite web adapter guide](https://github.com/StasDoskalenko/NitromelonDB/blob/master/docs-website/docs/docs/Implementation/WaSQLiteAdapter.md).
 
 Full credit to [@Nozbe](https://github.com/Nozbe) and [Radek Pietruszewski](https://github.com/radex) for designing and shipping the original WatermelonDB.
 


### PR DESCRIPTION
## The failure

`Deploy docs` has been red on every push since #119 merged (last green run: 2026-09-04). Not related to any recent dependency PR — those just re-triggered the workflow via the `docs-website/**` path filter.

CI log:

```
[WARNING] Docs markdown link couldn't be resolved: (docs-website/docs/docs/Implementation/WaSQLiteAdapter.md)
  in source file ".../docs-website/docs/docs/README.md"
[ERROR] Docusaurus found broken links!
  - Broken link on source page path = /NitromelonDB/docs:
     -> linking to docs-website/docs/docs/Implementation/WaSQLiteAdapter.md
```

## Cause

#119 added this to the root `README.md`:

```md
documented in the [wa-sqlite web adapter guide](docs-website/docs/docs/Implementation/WaSQLiteAdapter.md).
```

`scripts/update-docusaurus` copies `README.md` verbatim into `docs-website/docs/docs/README.md` and only rewrites `](./examples/` links. So that bare relative path lands in the docs README, where Docusaurus resolves it relative to the docs README's own location and can't find it. The build fails with the default `onBrokenLinks: 'throw'`.

(A local `yarn --cwd docs-website build` without running `update-docusaurus` first passes, because the checked-in `docs-website/docs/docs/README.md` copy is stale and predates the bad link — which is why this slipped through.)

## Fix

Use the full `github.com/.../blob/master/...` URL, matching the existing `Sync/Intro.md` link in the same README. `Installation.mdx` already links to the guide correctly with `./Implementation/WaSQLiteAdapter.md`, so nothing else needs to change.

Verified locally: `./scripts/update-docusaurus && yarn --cwd docs-website build` completes with no broken links.
