### PR TITLE
ci: bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-24.04
     name: ESLint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-24.04
     name: TypeScript
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
@@ -54,12 +54,12 @@ jobs:
     runs-on: ubuntu-24.04
     name: JavaScript tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
@@ -70,7 +70,7 @@ jobs:
       - run: node scripts/next-version.mjs --self-test
       - run: node scripts/prepare-changelog.mjs --self-test
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v5
   notesapp-web:
     needs: [eslint, typescript, ci-check]
     runs-on: ubuntu-24.04
@@ -80,9 +80,9 @@ jobs:
       CI: true
       EXPO_NO_TELEMETRY: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - run: yarn install --immutable
@@ -99,7 +99,7 @@ jobs:
         run: yarn test:web
       - name: Upload Playwright diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: notesapp-web-playwright-${{ github.run_attempt }}
           if-no-files-found: ignore
@@ -112,9 +112,9 @@ jobs:
     name: iOS tests
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Set Xcode version
@@ -124,13 +124,13 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
       - name: cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
       - name: cache Pods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: pods-cache
         with:
           path: native/iosTest/Pods
@@ -145,31 +145,31 @@ jobs:
     name: Android tests
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
       - run: yarn dev:native &
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v5
       # See: https://github.com/android/compose-samples/actions/runs/27015993/workflow for ideas for caching
       # android-emulator-runner runs each YAML line via `sh -c`, so keep this a single command.
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2.33.0
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 29
           working-directory: ./native/androidTest
@@ -184,21 +184,21 @@ jobs:
       CI: true
       EXPO_NO_TELEMETRY: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -206,7 +206,7 @@ jobs:
       - name: Install NotesApp
         working-directory: examples/NotesApp
         run: yarn install --immutable
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v5
       - name: Expo prebuild Android
         working-directory: examples/NotesApp
         run: yarn expo prebuild --platform android --non-interactive --no-install
@@ -222,13 +222,13 @@ jobs:
       # Runs the real e2e suite (blocking) then a flashlight perf measurement on the
       # same build/emulator (informational only, see scripts/ci-notesapp-android-maestro.sh).
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2.33.0
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 29
           profile: pixel
           disable-animations: true
           script: bash scripts/ci-notesapp-android-maestro.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: perf-result-android
@@ -243,9 +243,9 @@ jobs:
       CI: true
       EXPO_NO_TELEMETRY: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Set Xcode version
@@ -254,7 +254,7 @@ jobs:
           xcode-version: latest-stable
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -270,7 +270,7 @@ jobs:
         # there's no committed Podfile.lock to key a cache off before this.
         run: yarn expo prebuild --platform ios --non-interactive --no-install
       - name: cache Pods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             examples/NotesApp/ios/Pods
@@ -295,17 +295,17 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
         with:
           name: perf-result-android
           path: perf-results
         continue-on-error: true
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
@@ -327,19 +327,19 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: perf-result-android
           path: perf-results
         continue-on-error: true
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
@@ -385,15 +385,15 @@ jobs:
         working-directory: examples/NotesApp_windows
         shell: pwsh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.19.0'
           cache: yarn
           cache-dependency-path: examples/NotesApp_windows/yarn.lock
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.nuget/packages
@@ -416,7 +416,7 @@ jobs:
         run: yarn test:windows:e2e
       - name: Upload e2e failure diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: notesapp-windows-e2e-diagnostics
           path: examples/NotesApp_windows/.tmp/diagnostics

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,24 +62,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Set Node.js version
         if: matrix.build-mode == 'manual'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 
       - name: Cache node_modules
         if: matrix.build-mode == 'manual'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-24.x-modules-${{ hashFiles('**/yarn.lock') }}
@@ -90,11 +90,11 @@ jobs:
 
       - name: Set up Android SDK
         if: matrix.language == 'java-kotlin'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Set up Gradle
         if: matrix.language == 'java-kotlin'
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Set Xcode version
         if: matrix.language == 'swift'
@@ -104,7 +104,7 @@ jobs:
 
       - name: Cache CocoaPods
         if: matrix.language == 'swift'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: native/iosTest/Pods
           key: ${{ runner.os }}-pods-cache-${{ hashFiles('**/Podfile.lock') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,13 +30,13 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Enable Corepack
         run: corepack enable
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: yarn
@@ -51,7 +51,7 @@ jobs:
         working-directory: docs-website
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs-website/build
 
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -42,7 +42,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 

--- a/.github/workflows/simdjson.yml
+++ b/.github/workflows/simdjson.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: Vendor latest simdjson
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Vendor latest simdjson if newer
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/vendor-simdjson.mjs --latest --if-newer
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         if: steps.vendor.outputs.updated == 'true'
         with:
           branch: chore/simdjson-bump

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-24.04
     name: Vendor latest SQLite
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Vendor latest SQLite if newer
         id: vendor
         run: node scripts/vendor-sqlite.mjs --latest --if-newer
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         if: steps.vendor.outputs.updated == 'true'
         with:
           branch: chore/sqlite-bump

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,9 +21,9 @@ jobs:
     name: actionlint + action-validator
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Lint GitHub workflows


### PR DESCRIPTION
Every CI run has been printing a wall of *"Node.js 20 is deprecated ... forced to run on Node.js 24"* warnings (GitHub's [2025-09-19 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This bumps each action to its lowest major that ships a Node 24 runtime.

| Action | From | To | Note |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | matches `publish-release.yml`, which was already ahead |
| `actions/setup-node` | v4 | **v6** | |
| `actions/cache` | v4 | **v5** | v4 is node20 |
| `actions/setup-java` | v4 | **v5** | + `distribution: adopt → temurin` (adopt is retired) |
| `actions/upload-artifact` | v4 | **v6** | v5 is still node20 |
| `actions/download-artifact` | v4 | **v7** | v6 is still node20 |
| `actions/upload-pages-artifact` | v3 | **v5** | matched pair with deploy-pages |
| `actions/deploy-pages` | v4 | **v5** | |
| `gradle/actions/setup-gradle` | v3 | **v5** | v4 is still node20; used bare, no `with:` |
| `gradle/actions/wrapper-validation` | v4 | **v5** | |
| `android-actions/setup-android` | v3 | **v4** | used bare |
| `reactivecircus/android-emulator-runner` | v2.33.0 | **v2.38.0** | |
| `peter-evans/create-pull-request` | v7 | **v8** | v7 is node20 |

**Left as-is:**
- `hendrikmuhs/ccache-action@v1` — no Node 24 release exists yet, so the iOS jobs keep that one warning.
- `maxim-lobanov/setup-xcode@v1`, `github/codeql-action/*@v4` — already on Node 24.

**Not fixable in this PR** (from the same annotations page):
- The intermittent *"Failed to save cache entry ... Cache service responded with 400"* lines were a GitHub Actions cache-service outage during that run.
- The `jsi` / `hermes` / `RuntimeScheduler` Xcode warnings come from React Native / Expo pods, not this repo.

Local `node scripts/lint-workflows.mjs` (actionlint + action-validator) passes. The real check is CI here — the Android emulator, iOS, Windows, and Maestro jobs exercise the riskier bumps (`setup-gradle`, `android-emulator-runner`, `setup-android`). `docs.yml`'s pages actions only run on push to master, so those land unverified until merge (standard matched GitHub Pages pair, low risk).
