### PR TITLE
chore(examples): bump @xmldom/xmldom to 0.8.15 in NotesApp_windows

### DIFF
--- a/examples/NotesApp_windows/package.json
+++ b/examples/NotesApp_windows/package.json
@@ -53,6 +53,10 @@
     "react-test-renderer": "19.2.3",
     "typescript": "^5.8.3"
   },
+  "resolutions": {
+    "@react-native-windows/cli/@xmldom/xmldom": "^0.8.15",
+    "@react-native-windows/telemetry/@xmldom/xmldom": "^0.8.15"
+  },
   "engines": {
     "node": ">= 22.11.0"
   },

--- a/examples/NotesApp_windows/yarn.lock
+++ b/examples/NotesApp_windows/yarn.lock
@@ -3525,10 +3525,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.7.7":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: 10c0/cb02e4e8d986acf18578a5f25d1bce5e18d08718f40d8a0cdd922a4c112c8e00daf94de4e43f9556ed147c696b135f2ab81fa9a2a8a0416f60af15d156b60e40
+"@xmldom/xmldom@npm:^0.8.15":
+  version: 0.8.15
+  resolution: "@xmldom/xmldom@npm:0.8.15"
+  checksum: 10c0/59d09b85824b684fba5a0a224d5b43abea1a0d745e8d8b8136a7013e996eb6da122fdbb3deb32ed1621923a10e1937b1f7917cea43481d9d5b976e8c1ff836c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves Dependabot alert #256 — **GHSA-2v35-w6hq-6mfw / CVE-2026-41673** (high): uncontrolled recursion in `@xmldom/xmldom` `< 0.8.13`, allowing a DoS (`RangeError: Maximum call stack size exceeded`) via a single deeply nested XML document.

## Where it comes from

`examples/NotesApp_windows` resolved `@xmldom/xmldom@0.7.13` transitively through:

- `@react-native-windows/cli` (`^0.7.7`)
- `@react-native-windows/telemetry` (`^0.7.7`)

Both are dev-only Windows build tooling, used only during `react-native run-windows` / `init-windows` to read and patch project XML (`.vcxproj` / `.sln`). Not shipped by the `nitromelondb` library and not exercised by the example app's Jest tests.

## Fix

Scoped `resolutions` in `examples/NotesApp_windows/package.json` forcing the patched `0.8.15` for both consumers. Lockfile regenerated (`yarn install --mode update-lockfile`); the only resolution change is `@xmldom/xmldom` `0.7.13 → 0.8.15`. The `0.8` line is API-compatible with the XML read/patch usage in RNW 0.84.

This mirrors the existing `@xmldom/xmldom` resolutions already used in `examples/NotesApp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)