### PR TITLE
chore(docs): clear high-severity Dependabot advisories in build-time deps

### DIFF
--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -26,13 +26,19 @@
     "@docusaurus/module-type-aliases": "3.7.0"
   },
   "//resolutions": "webpackbar <7 passes name/color opts straight to webpack.ProgressPlugin, which webpack >=5.99 rejects with a schema error and breaks `docusaurus build`. v7 is what Docusaurus 3.10 ships; drop this on the next Docusaurus upgrade.",
-  "//resolutions-minimatch": "minimatch 3.1.2 (pulled transitively by glob/serve-handler/fork-ts-checker-webpack-plugin/recursive-readdir, all build-time) has ReDoS advisories GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74; 3.1.5 is the patched 3.x line and API-compatible. Drop once the Docusaurus dep tree ships >=3.1.5 itself.",
+  "//resolutions-security": "The remaining pins clear Dependabot advisories in Docusaurus build-time transitives (none ship to the built site). minimatch: ReDoS GHSA-3ppc-4f35-3m26 / GHSA-7r86-cg39-jmmj / GHSA-23c5-xmqv-rm74 (via glob, serve-handler, fork-ts-checker-webpack-plugin, recursive-readdir). js-yaml: GHSA-2883-xcg3-v3hh (prototype pollution). ws: DoS GHSA-96hv-2xvq-fx4p. path-to-regexp: ReDoS GHSA-37ch-88jc-xwx2. serialize-javascript: XSS GHSA-5c6j-r48x-rmvq (via copy/css-minimizer/terser webpack plugins). Drop each once the dep tree ships the fixed version itself.",
   "resolutions": {
     "webpackbar": "7.0.0",
     "minimatch@npm:3.1.2": "3.1.5",
     "minimatch@npm:^3.0.4": "3.1.5",
     "minimatch@npm:^3.0.5": "3.1.5",
-    "minimatch@npm:^3.1.1": "3.1.5"
+    "minimatch@npm:^3.1.1": "3.1.5",
+    "js-yaml@npm:^4.1.0": "^4.3.2",
+    "ws@npm:^8.13.0": "^8.21.0",
+    "path-to-regexp@npm:0.1.12": "0.1.13",
+    "serialize-javascript@npm:^6.0.0": "^7.0.3",
+    "serialize-javascript@npm:^6.0.1": "^7.0.3",
+    "serialize-javascript@npm:^6.0.2": "^7.0.3"
   },
   "browserslist": {
     "production": [

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -26,8 +26,13 @@
     "@docusaurus/module-type-aliases": "3.7.0"
   },
   "//resolutions": "webpackbar <7 passes name/color opts straight to webpack.ProgressPlugin, which webpack >=5.99 rejects with a schema error and breaks `docusaurus build`. v7 is what Docusaurus 3.10 ships; drop this on the next Docusaurus upgrade.",
+  "//resolutions-minimatch": "minimatch 3.1.2 (pulled transitively by glob/serve-handler/fork-ts-checker-webpack-plugin/recursive-readdir, all build-time) has ReDoS advisories GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74; 3.1.5 is the patched 3.x line and API-compatible. Drop once the Docusaurus dep tree ships >=3.1.5 itself.",
   "resolutions": {
-    "webpackbar": "7.0.0"
+    "webpackbar": "7.0.0",
+    "minimatch@npm:3.1.2": "3.1.5",
+    "minimatch@npm:^3.0.4": "3.1.5",
+    "minimatch@npm:^3.0.5": "3.1.5",
+    "minimatch@npm:^3.1.1": "3.1.5"
   },
   "browserslist": {
     "production": [

--- a/docs-website/yarn.lock
+++ b/docs-website/yarn.lock
@@ -7334,14 +7334,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
+"js-yaml@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 
@@ -9114,10 +9114,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.12":
-  version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12"
-  checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
+"path-to-regexp@npm:0.1.13":
+  version: 0.1.13
+  resolution: "path-to-regexp@npm:0.1.13"
+  checksum: 10c0/1cae3921739c154a8926e136185a10c916f79a249b9072a5001b266d96e193860ca03867e8e8cc808b786862d750f427ed93686bc259355442c3407a62deab1a
   languageName: node
   linkType: hard
 
@@ -10150,15 +10150,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
 "range-parser@npm:1.2.0":
   version: 1.2.0
   resolution: "range-parser@npm:1.2.0"
@@ -10823,7 +10814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
@@ -10988,12 +10979,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.0, serialize-javascript@npm:^6.0.1, serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+"serialize-javascript@npm:^7.0.3":
+  version: 7.1.1
+  resolution: "serialize-javascript@npm:7.1.1"
+  checksum: 10c0/a9209f0c3e946cc4421b705cfa502a28a7a5fed65eee22cb66b4200f374b2c3b8c9d0fadb6a00c75d7c0cd09c2780d1e0f390c75dce9d6dfb171f0b63c85014a
   languageName: node
   linkType: hard
 
@@ -12334,9 +12323,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.13.0":
-  version: 8.18.1
-  resolution: "ws@npm:8.18.1"
+"ws@npm:^8.21.0":
+  version: 8.21.3
+  resolution: "ws@npm:8.21.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -12345,7 +12334,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/e498965d6938c63058c4310ffb6967f07d4fa06789d3364829028af380d299fe05762961742971c764973dce3d1f6a2633fe8b2d9410c9b52e534b4b882a99fa
+  checksum: 10c0/7b28dc2863ea0e2cece68d142a3eee90361021b73f750431e6d8076bb7dede5fdfdb75b3d29534b62f411261147b76b1bc80fb5cc63ab0aabd467280e85b22e0
   languageName: node
   linkType: hard
 

--- a/docs-website/yarn.lock
+++ b/docs-website/yarn.lock
@@ -8522,12 +8522,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+"minimatch@npm:3.1.5":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears all remaining **high-severity** Dependabot alerts in `docs-website`. Every affected package is a Docusaurus **build-time** transitive — none ship to the generated site.

| Alert(s) | Package | Bump | Advisory |
|---|---|---|---|
| #20, #21, #22 | `minimatch` | 3.1.2 → 3.1.5 | ReDoS — GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74 |
| #328, #72, #58 | `js-yaml` (4.x) | 4.1.0 → 4.3.2 | prototype pollution — GHSA-2883-xcg3-v3hh |
| #47 | `ws` (8.x) | 8.18.1 → 8.21.3 | DoS — GHSA-96hv-2xvq-fx4p |
| #33 | `path-to-regexp` (0.1.x) | 0.1.12 → 0.1.13 | ReDoS — GHSA-37ch-88jc-xwx2 |
| #23 | `serialize-javascript` (6.x) | 6.0.2 → 7.1.1 | XSS — GHSA-5c6j-r48x-rmvq |

## Approach

Scoped `resolutions` in `docs-website/package.json`, each targeting only the vulnerable descriptor (the unaffected `js-yaml@3.x` / `ws@7.x` / `path-to-regexp@1.x`,`3.x` copies are left alone). Lockfile regenerated — diff is only the bumped packages.

`serialize-javascript` 6 → 7 is a major bump; its consumers here are `terser-webpack-plugin`, `css-minimizer-webpack-plugin` and `copy-webpack-plugin`, which use it to serialize cache keys — drop-in for that use.

## Verification

- `yarn install --immutable` — clean (only a pre-existing `@types/react` peer warning)
- `yarn build` (Docusaurus production build) — succeeds

## Out of scope

`image-size` (#75, #76) and the other no-fix advisories have no patched version upstream and stay open by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
