### PR TITLE
chore(deps): pin tmp to >=0.2.6 (path traversal)

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,5 +192,9 @@
     "semver": "^7.8.5",
     "typescript": "^6.0.3"
   },
+  "//resolutions": "tmp: path traversal GHSA-ph9p-34f9-6g65 (< 0.2.6). Pulled in dev-only via inquirer -> external-editor -> tmp@^0.0.33; external-editor is unmaintained and still pins 0.0.33. 0.2.x keeps the tmpNameSync/fileSync API external-editor uses. Drop once inquirer/external-editor moves off it.",
+  "resolutions": {
+    "tmp@npm:^0.0.33": "^0.2.6"
+  },
   "packageManager": "yarn@4.18.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9373,13 +9373,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
-  languageName: node
-  linkType: hard
-
 "own-keys@npm:^1.0.1":
   version: 1.0.1
   resolution: "own-keys@npm:1.0.1"
@@ -11182,12 +11175,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
+"tmp@npm:^0.2.6":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears Dependabot alert **#225** — `tmp` path traversal (GHSA-ph9p-34f9-6g65, high): `tmp < 0.2.6` lets an unsanitized `prefix`/`postfix` escape the temp directory.

## Where it comes from

Dev-only transitive in the library's own toolchain:

```
inquirer@9.3.7 → external-editor@3.1.0 → tmp@0.0.33
```

`external-editor` is unmaintained and still pins `tmp@^0.0.33`. `tmp` 0.2.x keeps the `tmpNameSync` / `fileSync({prefix, postfix})` API `external-editor` calls.

## Fix

New root `resolutions` block forcing `tmp@^0.2.6` (resolves to 0.2.7). Lockfile diff is just `tmp` 0.0.33 → 0.2.7 and the now-unused `os-tmpdir` dropped.

## Verification

- `yarn install --immutable` — clean
- `yarn test` — 94 suites, 938 passing / 23 skipped (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
