### PR TITLE
chore(examples): pin js-yaml to 4.3.2 in NotesApp_windows

### DIFF
--- a/examples/NotesApp_windows/package.json
+++ b/examples/NotesApp_windows/package.json
@@ -55,7 +55,8 @@
   },
   "resolutions": {
     "@react-native-windows/cli/@xmldom/xmldom": "^0.8.15",
-    "@react-native-windows/telemetry/@xmldom/xmldom": "^0.8.15"
+    "@react-native-windows/telemetry/@xmldom/xmldom": "^0.8.15",
+    "js-yaml@npm:^4.1.0": "^4.3.2"
   },
   "engines": {
     "node": ">= 22.11.0"

--- a/examples/NotesApp_windows/yarn.lock
+++ b/examples/NotesApp_windows/yarn.lock
@@ -7514,14 +7514,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+"js-yaml@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears Dependabot alert **#349** — `js-yaml` uncontrolled CPU on empty merge sources (GHSA-2883-xcg3-v3hh, high): `js-yaml >= 4.0.0, < 4.3.2`.

## Where it comes from

`examples/NotesApp_windows` resolved `js-yaml@4.3.1` transitively via `eslint@8.57.1`, `@eslint/eslintrc` and `cosmiconfig` — all dev tooling.

## Fix

Extended the existing `resolutions` block with `js-yaml@npm:^4.1.0` → `^4.3.2` (resolves to 4.3.2). Scoped to the 4.x descriptor; the unaffected `js-yaml@3.15.2` copy (via `@istanbuljs/load-nyc-config`) is untouched. Lockfile diff is a single line.

## Verification

`yarn install --immutable` clean. (`yarn test` fails locally here on both this branch and master with an unrelated pre-existing jest/RN-transform config issue — CI's "Windows NotesApp" job builds natively, it doesn't run this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
