### PR TITLE
fix(android): skip explicit Kotlin plugin when AGP registers the kotlin extension

### DIFF
--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -27,7 +27,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"


### PR DESCRIPTION
## Problem

Android Gradle Plugin 9 ships built-in Kotlin support and enables it by default, so AGP registers the `kotlin` extension itself. When the library *also* applies `kotlin-android` explicitly, the two collide and configuration fails before anything compiles:

```
> Failed to apply plugin 'kotlin-android'.
   > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```
```
> The 'kotlin-android' plugin is no longer required for Kotlin support since AGP 9.0.
```

The apply in `native/android/build.gradle` is unconditional, so on an AGP 9 project this module cannot be built at all. There is no consumer-side workaround short of patching the file — `android.builtInKotlin=false` project-wide just to build one dependency is not reasonable, and that escape hatch is removed in AGP 10.

## Change

Apply the plugin only when nothing has registered the `kotlin` extension yet:

```groovy
if (project.extensions.findByName('kotlin') == null) {
    apply plugin: 'kotlin-android'
}
```

The guard sits after `apply plugin: 'com.android.library'`, so AGP has already registered its extensions by the time it runs. This tests the condition that actually fails, so there is no AGP version table to keep in sync, and it covers AGP 10 — where the `android.builtInKotlin` opt-out is removed — without a special case.

| AGP | `android.builtInKotlin` | `kotlin` extension | explicit apply |
|---|---|---|---|
| 8.x | unset or `false` | absent | yes (unchanged) |
| 9.x | unset or `true` | registered by AGP | no |
| 9.x | `false` | absent | yes |
| 10+ | n/a (removed) | registered by AGP | no |

## Provenance

Ported from [Nozbe/WatermelonDB#1974](https://github.com/Nozbe/WatermelonDB/pull/1974).

🤖 Generated with [Claude Code](https://claude.com/claude-code)