### PR TITLE
docs(changelog): backfill 0.30.1-beta.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Contributors: Please add your changes to CHANGELOG-Unreleased.md
 
 ## 0.30.1-beta.1 - 2026-09-11
 
+### Fixes
+
+- [Android] `native/android/build.gradle` no longer applies `kotlin-android` unconditionally. AGP 9 registers a `kotlin` extension itself and enables built-in Kotlin support by default, so the explicit apply collided with it ("Cannot add extension with name 'kotlin'"), making the module unbuildable on AGP 9 projects with no consumer-side workaround. The plugin is now applied only when nothing has registered that extension yet, which also covers AGP 10 (where the `android.builtInKotlin` opt-out is removed).
+
+### Internal
+
+- Dependabot cleanup across the example apps and docs site — none of these ship in the published `nitromelondb` package:
+  - `examples/NotesApp_windows`: `@xmldom/xmldom` 0.7.13 → 0.8.15 (GHSA-2v35-w6hq-6mfw, uncontrolled recursion DoS) and `js-yaml` 4.x → 4.3.2 (GHSA-2883-xcg3-v3hh, uncontrolled CPU on empty merge sources), both dev-only transitives.
+  - `docs-website`: `minimatch` → 3.1.5, `js-yaml` (4.x) → 4.3.2, `ws` → 8.21.3, `path-to-regexp` (0.1.x) → 0.1.13, `serialize-javascript` 6 → 7.1.1 — all Docusaurus build-time transitives, none shipped in the generated site.
+  - Root toolchain: `tmp` 0.0.33 → 0.2.7 (GHSA-ph9p-34f9-6g65, path traversal), pulled in transitively via `inquirer` → `external-editor`.
+  - `examples/typescript`: dropped the unmaintained `tsd-check` dev dependency (its only use was a single `expectType` call, replaced with a local type-only helper), clearing its `braces`/`got`/`yargs-parser`/`decode-uri-component` advisory chain.
+
 ## 0.30.1-beta.0 - 2026-09-10
 
 ### New features

--- a/docs-website/docs/docs/CHANGELOG.md
+++ b/docs-website/docs/docs/CHANGELOG.md
@@ -6,6 +6,18 @@ Contributors: Please add your changes to CHANGELOG-Unreleased.md
 
 ## 0.30.1-beta.1 - 2026-09-11
 
+### Fixes
+
+- [Android] `native/android/build.gradle` no longer applies `kotlin-android` unconditionally. AGP 9 registers a `kotlin` extension itself and enables built-in Kotlin support by default, so the explicit apply collided with it ("Cannot add extension with name 'kotlin'"), making the module unbuildable on AGP 9 projects with no consumer-side workaround. The plugin is now applied only when nothing has registered that extension yet, which also covers AGP 10 (where the `android.builtInKotlin` opt-out is removed).
+
+### Internal
+
+- Dependabot cleanup across the example apps and docs site — none of these ship in the published `nitromelondb` package:
+  - `examples/NotesApp_windows`: `@xmldom/xmldom` 0.7.13 → 0.8.15 (GHSA-2v35-w6hq-6mfw, uncontrolled recursion DoS) and `js-yaml` 4.x → 4.3.2 (GHSA-2883-xcg3-v3hh, uncontrolled CPU on empty merge sources), both dev-only transitives.
+  - `docs-website`: `minimatch` → 3.1.5, `js-yaml` (4.x) → 4.3.2, `ws` → 8.21.3, `path-to-regexp` (0.1.x) → 0.1.13, `serialize-javascript` 6 → 7.1.1 — all Docusaurus build-time transitives, none shipped in the generated site.
+  - Root toolchain: `tmp` 0.0.33 → 0.2.7 (GHSA-ph9p-34f9-6g65, path traversal), pulled in transitively via `inquirer` → `external-editor`.
+  - `examples/typescript`: dropped the unmaintained `tsd-check` dev dependency (its only use was a single `expectType` call, replaced with a local type-only helper), clearing its `braces`/`got`/`yargs-parser`/`decode-uri-component` advisory chain.
+
 ## 0.30.1-beta.0 - 2026-09-10
 
 ### New features


### PR DESCRIPTION
## Problem

The v0.30.1-beta.1 [release page](https://github.com/StasDoskalenko/NitromelonDB/releases/tag/v0.30.1-beta.1) just says "See the changelog for details." instead of real notes.

The release PR (#135) rolled `CHANGELOG-Unreleased.md` into `CHANGELOG.md` with an **empty** `## 0.30.1-beta.1` heading, because none of the PRs merged between beta.0 and beta.1 (#129-#134: example-app/docs dependency security bumps, and the AGP9 Kotlin-plugin fix) added an entry to `CHANGELOG-Unreleased.md`. The prepare-release workflow actually flagged this correctly — the PR body said *"_No unreleased notes were recorded._"* — but it was merged anyway, so `publish-release.yml`'s `extract` step found nothing and fell back to the generic text.

This isn't an automation bug; it's a gap in what got merged.

## Fix

Backfill real entries under the existing `0.30.1-beta.1` heading in `CHANGELOG.md` and its `docs-website` mirror, summarizing:
- the AGP9 `kotlin-android` plugin guard fix
- the Dependabot/security dependency bumps across example apps, docs-website, and root dev tooling

Verified `node scripts/prepare-changelog.mjs extract 0.30.1-beta.1` now returns this content, and `--self-test` still passes.

Once merged, I'll update the live GitHub release notes for `v0.30.1-beta.1` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)