### PR TITLE
ci(release): fail Prepare Release on an empty CHANGELOG-Unreleased.md

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,7 @@ Automated releases for `nitromelondb`, modeled on the two-step process used in [
 | Version bump | `none`, `promote`, `patch`, `minor`, `major` | Semver bump. `none` keeps the current X.Y.Z (next `-alpha.N`, or graduate if prerelease is `none`). `promote` ships the in-progress alpha/beta as official `X.Y.Z` and folds the changelog |
 | Prerelease | `none`, `alpha`, `beta` | Optional prerelease channel. Ignored when bump is `promote` |
 | npm dist-tag | `none`, `latest`, `alpha`, `beta` | `none` (default) uses the version's channel tag. Pick `latest` only when this version should be what `npm i nitromelondb` installs |
+| Allow empty changelog | `true`, `false` (default `false`) | The workflow fails if `CHANGELOG-Unreleased.md` has no entries — add one, or check this only for a release that genuinely has no user-facing changes |
 
 **What it does:**
 
@@ -22,7 +23,7 @@ Automated releases for `nitromelondb`, modeled on the two-step process used in [
 2. Skips versions that already have a git tag, GitHub Release, or npm publish (alpha/beta then increment `-alpha.N`)
 3. Creates or recreates a `release/vX.Y.Z` branch from master (leftover branches without a tag/release are reused; already-open PRs are not)
 4. Bumps `package.json`
-5. Moves `CHANGELOG-Unreleased.md` into `CHANGELOG.md` under the new version heading
+5. Moves `CHANGELOG-Unreleased.md` into `CHANGELOG.md` under the new version heading, failing the run if it's empty and `allow_empty_changelog` isn't set
 6. When graduating to a stable release (`promote`, or bump `none` + prerelease `none`), folds every same-version `-alpha.N` / `-beta.N` changelog entry into that one official heading and removes the prerelease sections
 7. Records the npm dist-tag choice in `.github/publish-npm-tag` (always written, including `none`)
 8. Resets `CHANGELOG-Unreleased.md` to empty section headers

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,6 +33,11 @@ on:
           - alpha
           - beta
         default: 'none'
+      allow_empty_changelog:
+        description: 'Allow preparing a release with no CHANGELOG-Unreleased.md entries (rare -- normally add an entry to CHANGELOG-Unreleased.md instead)'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   prepare:
@@ -197,9 +202,13 @@ jobs:
           # blank lines) is actually caught instead of silently producing a
           # release with an empty changelog section further down the line.
           if [ -z "$(tr -d '[:space:]' < /tmp/release_notes.md)" ]; then
+            if [ "${{ inputs.allow_empty_changelog }}" != "true" ]; then
+              echo "::error::No CHANGELOG-Unreleased.md entries were found for v${{ env.NEW_VERSION }}. Add an entry to CHANGELOG-Unreleased.md (see CONTRIBUTING.md or the file's own header comment) before preparing this release, or re-run this workflow with 'allow_empty_changelog' checked if it genuinely has no user-facing changes."
+              exit 1
+            fi
             echo "_No unreleased notes were recorded._" > /tmp/release_notes.md
             echo "NOTES_EMPTY=true" >> "$GITHUB_ENV"
-            echo "::warning::No CHANGELOG-Unreleased.md entries were found for v${{ env.NEW_VERSION }}. Contributors should add an entry to CHANGELOG-Unreleased.md in their PR -- see CONTRIBUTING or the file's own header comment. Review this release PR's changelog section before merging."
+            echo "::warning::Preparing v${{ env.NEW_VERSION }} with no CHANGELOG-Unreleased.md entries (allow_empty_changelog was set). Review this release PR's changelog section before merging."
           else
             echo "NOTES_EMPTY=false" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
## Problem

v0.30.1-beta.1 shipped with no changelog content (see #136). Root cause: none of the PRs merged since beta.0 added an entry to `CHANGELOG-Unreleased.md`. `prepare-release.yml` actually detected this correctly — the release PR (#135) body said *"_No unreleased notes were recorded._"* with a `::warning::` annotation — but that was only advisory. The PR got merged anyway, and the empty heading made it all the way into `CHANGELOG.md` and the published GitHub Release.

## Fix

Turn the warning into a hard failure. `prepare-release.yml` now exits with `::error::` before the release branch is pushed or the PR is opened, whenever `CHANGELOG-Unreleased.md` is empty:

```
No CHANGELOG-Unreleased.md entries were found for vX.Y.Z. Add an entry to
CHANGELOG-Unreleased.md (see CONTRIBUTING.md or the file's own header comment)
before preparing this release, or re-run this workflow with
'allow_empty_changelog' checked if it genuinely has no user-facing changes.
```

A new `allow_empty_changelog` boolean input (default `false`) is the deliberate escape hatch for a release that really has no user-facing changes — it keeps the old warning + placeholder-notes behavior in that case.

The failure happens in the "Roll CHANGELOG-Unreleased.md into CHANGELOG.md" step, before the release branch is committed or pushed, so a failed run leaves no half-prepared state on `origin` to clean up.

## Verification

- `node scripts/lint-workflows.mjs` (actionlint + action-validator) passes.
- Manually traced the new branch: `allow_empty_changelog=false` + empty `CHANGELOG-Unreleased.md` → `exit 1` before any push; `allow_empty_changelog=true` → same placeholder-notes/warning path as before.

## Docs

Updated `.github/workflows/README.md`'s Prepare Release inputs table and step list to document the new input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)