### PR TITLE
fix(Query): batch mass delete into a single transaction

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -10,6 +10,8 @@
 
 ### Performance
 
+- `Query.markAllAsDeleted()` / `Query.destroyAllPermanently()` are dramatically faster and no longer scale with how many records match: previously each matching record was deleted individually (one `database.batch()` call, i.e. one transaction, per record), then a full row fetch per matching record even after that was batched into one transaction. Now every backend (SQLite native/iOS/Android/Windows, sqlite-node, sqlite-wasm, LokiJS) resolves and deletes matching records in a single operation, and clearing a whole table (`collection.query().destroyAllPermanently()`) can take SQLite's own page-truncation fast path instead of deleting row by row.
+
 ### Changes
 
 ### Internal

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -10,7 +10,7 @@
 
 ### Performance
 
-- `Query.markAllAsDeleted()` / `Query.destroyAllPermanently()` are dramatically faster and no longer scale with how many records match: previously each matching record was deleted individually (one `database.batch()` call, i.e. one transaction, per record), then a full row fetch per matching record even after that was batched into one transaction. Now every backend (SQLite native/iOS/Android/Windows, sqlite-node, sqlite-wasm, LokiJS) resolves and deletes matching records in a single operation, and clearing a whole table (`collection.query().destroyAllPermanently()`) can take SQLite's own page-truncation fast path instead of deleting row by row.
+- `Query.markAllAsDeleted()` / `Query.destroyAllPermanently()` are dramatically faster and no longer scale with how many records match: previously each matching record was deleted individually (one `database.batch()` call, i.e. one transaction, per record), then a full row fetch per matching record even after that was batched into one transaction. Now every backend (SQLite native/iOS/Android/Windows, sqlite-node, sqlite-wasm, LokiJS) resolves and deletes matching records in a single operation, and clearing a whole table (`collection.query().destroyAllPermanently()`) can take SQLite's own page-truncation fast path instead of deleting row by row. Run `yarn benchmark:destroy-all` for a real, reproducible old-vs-new timing comparison against a real SQLite database (e.g. ~1.6s vs ~11ms clearing 5,000 rows on a MacBook -- see `src/adapters/__tests__/sqliteTests/destroyAll.benchmark.js`).
 
 ### Changes
 

--- a/docs-website/docs/docs/CRUD.md
+++ b/docs-website/docs/docs/CRUD.md
@@ -112,6 +112,27 @@ await somePost.destroyPermanently() // permanent
 
 **Note:** Do not access, update, or observe records after they're deleted.
 
+### Delete all records matching a query
+
+To delete more than one record at once — including clearing a whole table — use `Query.markAllAsDeleted()` / `Query.destroyAllPermanently()` instead of fetching and deleting records one by one, or dropping down to [raw SQL](#advanced-unsafe-raw-execute). It resolves and deletes matching records in a single operation, and — unlike raw SQL — keeps the in-memory record cache and any active observers correctly up to date.
+
+```js
+import { Q } from 'nitromelondb'
+
+await database.write(async () => {
+  // clear a whole table
+  await database.get('posts').query().destroyAllPermanently()
+
+  // delete only what matches a condition
+  await database.get('posts').query(Q.where('is_draft', true)).destroyAllPermanently()
+
+  // delete everything except a few ids
+  await database.get('posts').query(Q.where('id', Q.notIn(idsToKeep))).destroyAllPermanently()
+})
+```
+
+Use `markAllAsDeleted()` instead if you [synchronize](./Sync/Intro.md).
+
 ## Advanced
 
 - `Model.observe()` - usually you only use this [when connecting records to components](./Components.md), but you can manually observe a record outside of React components. The returned [RxJS](https://github.com/reactivex/rxjs) `Observable` will emit the record immediately upon subscription, and then every time the record is updated. If the record is deleted, the Observable will complete.
@@ -130,7 +151,7 @@ await somePost.destroyPermanently() // permanent
 
 ### Logging out / switching users
 
-Most apps use a single, long-lived `Database` instance and, on logout, either call `database.unsafeResetDatabase()` or drop down to raw SQL/adapter calls to wipe every table. Either way, **the safe pattern is to make sure nothing is still observing the database when you do this**:
+Most apps use a single, long-lived `Database` instance and, on logout, either call `database.unsafeResetDatabase()` or drop down to raw SQL/adapter calls to wipe every table. If you only need to clear specific tables rather than the whole database, prefer [`Query.destroyAllPermanently()`](#delete-all-records-matching-a-query) over raw SQL — it keeps the record cache and observers correct on its own. Either way, **the safe pattern is to make sure nothing is still observing the database when you do this**:
 
 - `unsafeResetDatabase()` clears each `Collection`'s internal record cache, but it does not — and cannot — reach into every `Query`/`Model` observer your app may still be holding onto. Its own doc comment says so explicitly: you must not hold onto records, collections, or other Watermelon objects, and all observers/subscribers should be disposed of first.
 - If a subscription genuinely stays alive across the reset (a persistent top-level component, a memoized `Query` held in module scope, a `useQuery`/`useRecord`/`withObservables`-connected component that didn't unmount), NitromelonDB now detects and self-heals it: any `Query` cache (`.observe()`, `.observeWithColumns()`, `.observeCount()`, and their Rx-free `experimentalSubscribe*()` equivalents) that's still actively subscribed when `unsafeResetDatabase()` runs is invalidated and immediately refetched, so the subscriber gets fresh (post-reset) data instead of being frozen on the previous user's data forever. This is a safety net for a real app bug, not a substitute for tearing subscriptions down properly — until that invalidation runs, the still-mounted component *will* briefly render the old user's data.

--- a/docs-website/docs/docs/Query.md
+++ b/docs-website/docs/docs/Query.md
@@ -312,6 +312,10 @@ It isn't _necessarily_ better or more efficient to sort on query level instead o
 
 If you only need IDs of records matching a query, you can optimize the query by calling `await query.fetchIds()` instead of `await query.fetch()`
 
+### Deleting matching records
+
+To delete every record matching a query — including clearing a whole table — use `query.markAllAsDeleted()` / `query.destroyAllPermanently()` instead of fetching and deleting records one by one. See [Delete all records matching a query](./CRUD.md#delete-all-records-matching-a-query) in the CRUD guide.
+
 ### Security
 
 Remember that Queries are a sensitive subject, security-wise. Never trust user input and pass it directly into queries. In particular:

--- a/examples/NotesApp/README.md
+++ b/examples/NotesApp/README.md
@@ -37,6 +37,7 @@ CI runs these flows on an Android emulator (`NotesApp Android (build)` then `Not
 | --- | --- |
 | `cold-start.yaml` | App launch, empty → seeded list (`100 notes`) |
 | `add-pin-delete.yaml` | Create, pin, delete against live observers |
+| `delete-all.yaml` | `Query#destroyAllPermanently()` clears the whole table in one shot |
 | `kill-and-relaunch.yaml` | Persistence across process kill |
 | `interaction-burst.yaml` | Rapid create / pin / delete |
 | `pagination-seed.yaml` | Sticky pager + `Q.skip` / `Q.take(20)` after seed |

--- a/examples/NotesApp/maestro/delete-all.yaml
+++ b/examples/NotesApp/maestro/delete-all.yaml
@@ -1,0 +1,41 @@
+# Delete every note in one shot via Query#destroyAllPermanently() (Note.deleteAllForever, called
+# by the "Delete all" button) against the live database — the unconditional "clear the whole
+# table" path (native/shared/Database-batch.cpp's Database::destroyMatching, isUnconditional
+# branch) that a JS unit test alone can't confirm actually compiles and runs on-device.
+# Run from examples/NotesApp: maestro test maestro/delete-all.yaml
+
+appId: com.nitromelondb.example
+---
+- launchApp:
+    clearState: true
+
+# Seed is async — wait for subtitle (only visible after seeding).
+- extendedWaitUntil:
+    visible:
+      id: "subtitle"
+    timeout: 60000
+
+- assertVisible:
+    text: ".*100 notes.*"
+
+- assertVisible:
+    text: "Note #100"
+
+- tapOn:
+    id: "delete-all-button"
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      text: ".*0 notes.*"
+    timeout: 15000
+
+- assertVisible:
+    text: ".*0 notes.*"
+
+- assertNotVisible:
+    text: "Note #100"
+
+# The button itself disables once there's nothing left to delete.
+- assertNotVisible:
+    text: "Deleting all…"

--- a/examples/NotesApp/src/model/Note.ts
+++ b/examples/NotesApp/src/model/Note.ts
@@ -28,6 +28,15 @@ export default class Note extends Model {
     })
   }
 
+  // Exercises Query#destroyAllPermanently()'s unconditional ("clear the whole table") fast path
+  // -- a bare `collection.query()` with no where/join/take/skip at all -- end to end against
+  // whichever native SQLite engine this app is actually built against, not just a JS unit test.
+  static async deleteAllForever(notes: Collection<Note>): Promise<void> {
+    await notes.database.write(async () => {
+      await notes.query().destroyAllPermanently()
+    })
+  }
+
   @text('title')
   title!: string
   @text('body')

--- a/examples/NotesApp/src/screens/NotesScreen.tsx
+++ b/examples/NotesApp/src/screens/NotesScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Keyboard, StyleSheet, Text, View } from 'react-native'
+import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native'
 import { ComposerDock } from '../components/ComposerDock'
 import { NotesComposer } from '../components/NotesComposer'
 import { NotesHeader } from '../components/NotesHeader'
@@ -21,6 +21,7 @@ export function NotesScreen({ db }: NotesScreenProps) {
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [busy, setBusy] = useState(false)
+  const [deletingAll, setDeletingAll] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
   // NotesComposer's Windows title field is uncontrolled (defaultValue) because
   // driver-injected/IME input there doesn't reliably fire onChangeText; bumping
@@ -73,6 +74,22 @@ export function NotesScreen({ db }: NotesScreenProps) {
     }
   }
 
+  const deleteAllNotes = async () => {
+    if (deletingAll) {
+      return
+    }
+    setActionError(null)
+    setDeletingAll(true)
+    try {
+      await Note.deleteAllForever(db.notes)
+      setPage(1)
+    } catch (writeError) {
+      setActionError(writeError instanceof Error ? writeError.message : String(writeError))
+    } finally {
+      setDeletingAll(false)
+    }
+  }
+
   return (
     // Keyboard-avoidance is scoped to the composer (ComposerDock), not the
     // whole screen: an earlier root-level KeyboardAvoidingView ate Maestro's
@@ -84,6 +101,23 @@ export function NotesScreen({ db }: NotesScreenProps) {
         schemaVersion={db.schemaVersion}
         totalCount={totalCount}
       />
+
+      <Pressable
+        onPress={() => void deleteAllNotes()}
+        disabled={deletingAll || totalCount === 0}
+        hitSlop={12}
+        style={[
+          styles.deleteAllButton,
+          (deletingAll || totalCount === 0) && styles.deleteAllButtonDisabled,
+        ]}
+        testID="delete-all-button"
+        accessibilityRole="button"
+        accessibilityLabel="Delete all notes"
+      >
+        <Text style={styles.deleteAllLabel} accessible={false}>
+          {deletingAll ? 'Deleting all…' : 'Delete all'}
+        </Text>
+      </Pressable>
 
       {actionError ? <Text style={styles.error}>{actionError}</Text> : null}
 
@@ -123,5 +157,24 @@ const styles = StyleSheet.create({
     color: colors.danger,
     fontSize: 14,
     textAlign: 'center',
+  },
+  deleteAllButton: {
+    alignSelf: 'flex-end',
+    marginHorizontal: 20,
+    marginBottom: 8,
+    minHeight: 32,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.danger,
+  },
+  deleteAllButtonDisabled: {
+    opacity: 0.35,
+  },
+  deleteAllLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.danger,
   },
 })

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -35,11 +35,16 @@ Below the main comparison, the NitromelonDB app has an extra, self-contained car
 old vs new". It seeds N rows twice into their own dedicated databases and times destroying all of
 them once via the pre-optimization `Query#destroyAllPermanently()` (one `database.batch()` call --
 one adapter transaction -- per matching record) and once via the current one (one
-`destroyMatching()` call total, regardless of match count). It's NitromelonDB-only -- there's
-nothing to compare against in the WatermelonDB app, since upstream never had `destroyMatching()`.
-See `nitromelondb_benchmark/massDeleteBenchmark.ts`, and
+`destroyMatching()` call total, regardless of match count). See
+`nitromelondb_benchmark/massDeleteBenchmark.ts`, and
 `src/adapters/__tests__/sqliteTests/destroyAll.benchmark.js` (`yarn benchmark:destroy-all` at the
 repo root) for the same comparison against Node/better-sqlite3.
+
+The WatermelonDB app has a matching "Mass delete (reference)" card -- upstream has no
+`destroyMatching()` to compare against internally, so it just times its own
+`Query#destroyAllPermanently()` at the same record counts. That number should land close to the
+NitromelonDB card's "old" column (same algorithm); the NitromelonDB card's "new" column is the
+improvement. See `watermelondb_benchmark/massDeleteBenchmark.ts`.
 
 ## WatermelonDB
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -29,6 +29,18 @@ npx expo run:android
 
 Links the local library via `link:../../..`. After native SQLite / Nitro changes, rebuild.
 
+### Mass delete: old vs new
+
+Below the main comparison, the NitromelonDB app has an extra, self-contained card: "Mass delete:
+old vs new". It seeds N rows twice into their own dedicated databases and times destroying all of
+them once via the pre-optimization `Query#destroyAllPermanently()` (one `database.batch()` call --
+one adapter transaction -- per matching record) and once via the current one (one
+`destroyMatching()` call total, regardless of match count). It's NitromelonDB-only -- there's
+nothing to compare against in the WatermelonDB app, since upstream never had `destroyMatching()`.
+See `nitromelondb_benchmark/massDeleteBenchmark.ts`, and
+`src/adapters/__tests__/sqliteTests/destroyAll.benchmark.js` (`yarn benchmark:destroy-all` at the
+repo root) for the same comparison against Node/better-sqlite3.
+
 ## WatermelonDB
 
 ```sh

--- a/examples/benchmark/nitromelondb_benchmark/App.tsx
+++ b/examples/benchmark/nitromelondb_benchmark/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { BenchmarkScreen } from '../shared/BenchmarkScreen'
 import { createNitromelonAdapter } from './database'
+import { MassDeleteBenchmarkCard } from './MassDeleteBenchmarkCard'
 
 const theme = {
   background: '#09090b',
@@ -31,6 +32,8 @@ export default function App() {
       adapter={session.ok ? session.adapter : null}
       setupError={session.ok ? null : session.message}
       theme={theme}
-    />
+    >
+      <MassDeleteBenchmarkCard theme={theme} />
+    </BenchmarkScreen>
   )
 }

--- a/examples/benchmark/nitromelondb_benchmark/MassDeleteBenchmarkCard.tsx
+++ b/examples/benchmark/nitromelondb_benchmark/MassDeleteBenchmarkCard.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import type { BenchmarkTheme } from '../shared/BenchmarkScreen'
+import { formatNumber } from '../shared/format'
+import { runMassDeleteBenchmark, type MassDeleteResult } from './massDeleteBenchmark'
+
+const SIZES = [1_000, 5_000, 20_000]
+
+function formatMs(ms: number): string {
+  return `${ms.toFixed(1)}ms`
+}
+
+function speedup({ oldMs, newMs }: MassDeleteResult): string {
+  return newMs > 0 ? `${(oldMs / newMs).toFixed(1)}x` : '—'
+}
+
+type Props = {
+  theme: BenchmarkTheme
+}
+
+// NitromelonDB-only: there's nothing to compare against in the WatermelonDB benchmark app since
+// upstream never had destroyMatching(). See massDeleteBenchmark.ts for what's actually measured.
+export function MassDeleteBenchmarkCard({ theme }: Props) {
+  const [size, setSize] = useState(SIZES[1]!)
+  const [running, setRunning] = useState(false)
+  const [results, setResults] = useState<MassDeleteResult[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const styles = createStyles(theme)
+
+  const run = async () => {
+    if (running) {
+      return
+    }
+    setRunning(true)
+    setError(null)
+    try {
+      const result = await runMassDeleteBenchmark(size)
+      setResults((current) => [result, ...current])
+    } catch (runError) {
+      setError(runError instanceof Error ? runError.message : String(runError))
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>Mass delete: old vs new</Text>
+      <Text style={styles.hint}>
+        Query#destroyAllPermanently() before this PR (one transaction per matching record) vs now
+        (one destroyMatching() call total). Each run seeds {formatNumber(size)} rows twice and
+        times destroying all of them, once each way.
+      </Text>
+
+      <View style={styles.sizeRow}>
+        {SIZES.map((candidate) => (
+          <Pressable
+            key={candidate}
+            style={[styles.chip, size === candidate && styles.chipActive, running && styles.disabled]}
+            onPress={() => setSize(candidate)}
+            disabled={running}
+          >
+            <Text style={[styles.chipLabel, size === candidate && styles.chipLabelActive]}>
+              {formatNumber(candidate)}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Pressable
+        style={[styles.button, running && styles.disabled]}
+        onPress={() => void run()}
+        disabled={running}
+      >
+        <Text style={styles.buttonLabel}>{running ? 'Running…' : 'Run comparison'}</Text>
+      </Pressable>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      {results.length > 0 ? (
+        <View style={styles.table}>
+          <View style={styles.tableHeader}>
+            <Text style={[styles.tableCell, styles.tableWide]}>Records</Text>
+            <Text style={styles.tableCell}>Old</Text>
+            <Text style={styles.tableCell}>New</Text>
+            <Text style={styles.tableCell}>Speedup</Text>
+          </View>
+          {results.map((result, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <View key={index} style={styles.tableRow}>
+              <Text style={[styles.tableCell, styles.tableWide]}>{formatNumber(result.count)}</Text>
+              <Text style={styles.tableCell}>{formatMs(result.oldMs)}</Text>
+              <Text style={styles.tableCell}>{formatMs(result.newMs)}</Text>
+              <Text style={styles.tableCell}>{speedup(result)}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+function createStyles(theme: BenchmarkTheme) {
+  return StyleSheet.create({
+    card: {
+      marginTop: 20,
+      backgroundColor: theme.card,
+      borderRadius: 16,
+      padding: 16,
+    },
+    cardTitle: {
+      color: theme.muted,
+      fontSize: 13,
+      fontWeight: '700',
+      letterSpacing: 0.6,
+      textTransform: 'uppercase',
+      marginBottom: 8,
+    },
+    hint: {
+      color: theme.muted,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    sizeRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 8,
+      marginTop: 14,
+    },
+    chip: {
+      borderWidth: 1,
+      borderColor: '#3f3f46',
+      borderRadius: 999,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+    },
+    chipActive: {
+      backgroundColor: theme.accent,
+      borderColor: theme.accent,
+    },
+    chipLabel: {
+      color: theme.muted,
+      fontSize: 13,
+      fontWeight: '600',
+    },
+    chipLabelActive: {
+      color: theme.accentText,
+    },
+    button: {
+      marginTop: 14,
+      backgroundColor: theme.accent,
+      borderRadius: 12,
+      paddingVertical: 12,
+      alignItems: 'center',
+    },
+    buttonLabel: {
+      color: theme.accentText,
+      fontSize: 15,
+      fontWeight: '700',
+    },
+    disabled: {
+      opacity: 0.45,
+    },
+    error: {
+      marginTop: 10,
+      color: theme.danger,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    table: {
+      marginTop: 14,
+    },
+    tableHeader: {
+      flexDirection: 'row',
+      paddingBottom: 8,
+      borderBottomWidth: 1,
+      borderBottomColor: '#27272a',
+    },
+    tableRow: {
+      flexDirection: 'row',
+      paddingVertical: 8,
+      borderBottomWidth: 1,
+      borderBottomColor: '#18181b',
+    },
+    tableCell: {
+      flex: 1,
+      color: theme.text,
+      fontSize: 12,
+      fontVariant: ['tabular-nums'],
+    },
+    tableWide: {
+      flex: 1.4,
+    },
+  })
+}

--- a/examples/benchmark/nitromelondb_benchmark/massDeleteBenchmark.ts
+++ b/examples/benchmark/nitromelondb_benchmark/massDeleteBenchmark.ts
@@ -1,0 +1,97 @@
+import { Database } from 'nitromelondb'
+import type { Collection } from 'nitromelondb'
+import SQLiteAdapter from 'nitromelondb/adapters/sqlite'
+import Item from './model/Item'
+import { ITEMS_TABLE, schema } from './model/schema'
+
+// A separate, dedicated database from the main write/query/delete comparison harness
+// (createNitromelonAdapter's `nitromelon-benchmark`) -- this benchmark measures one thing only:
+// Query#destroyAllPermanently() before this PR (one database.batch() call -- one adapter
+// transaction -- per matching record) vs after (one adapter.destroyMatching() call total,
+// regardless of match count). See src/adapters/__tests__/sqliteTests/destroyAll.benchmark.js for
+// the same comparison against a real file-backed SQLite database via Node/better-sqlite3; this is
+// the same idea against whatever this device's actual native SQLite engine is.
+
+export type MassDeleteResult = {
+  count: number
+  oldMs: number
+  newMs: number
+}
+
+type ItemDatabase = { database: Database; items: Collection<Item> }
+
+function now(): number {
+  return globalThis.performance?.now?.() ?? Date.now()
+}
+
+async function makeDatabase(dbName: string): Promise<ItemDatabase> {
+  const adapter = new SQLiteAdapter({ schema, dbName })
+  const database = new Database({ adapter, modelClasses: [Item] })
+  return { database, items: database.get<Item>(ITEMS_TABLE) }
+}
+
+async function reset(database: Database): Promise<void> {
+  await database.write(() => database.unsafeResetDatabase())
+}
+
+async function seed(items: Collection<Item>, count: number): Promise<void> {
+  await items.database.write(async () => {
+    const operations = []
+    for (let index = 0; index < count; index += 1) {
+      operations.push(
+        items.prepareCreate((item) => {
+          item.title = `item-${index}`
+          item.value = index % 1000
+          item.createdAt = index
+        }),
+      )
+    }
+    await items.database.batch(operations)
+  })
+}
+
+// Faithful to the pre-PR Query#destroyAllPermanently(): fetch full Model instances, then destroy
+// each one via its own database.batch() call -- one adapter transaction per record.
+async function oldDestroyAllPermanently(items: Collection<Item>): Promise<void> {
+  const records = await items.query().fetch()
+  await items.database.write(async () => {
+    for (const record of records) {
+      // eslint-disable-next-line no-await-in-loop
+      await items.database.batch(record.prepareDestroyPermanently())
+    }
+  })
+}
+
+async function newDestroyAllPermanently(items: Collection<Item>): Promise<void> {
+  await items.database.write(() => items.query().destroyAllPermanently())
+}
+
+let oldDb: ItemDatabase | null = null
+let newDb: ItemDatabase | null = null
+
+async function getDb(which: 'old' | 'new'): Promise<ItemDatabase> {
+  if (which === 'old') {
+    oldDb ??= await makeDatabase('nitromelon-massdelete-old')
+    return oldDb
+  }
+  newDb ??= await makeDatabase('nitromelon-massdelete-new')
+  return newDb
+}
+
+export async function runMassDeleteBenchmark(count: number): Promise<MassDeleteResult> {
+  const old = await getDb('old')
+  await reset(old.database)
+  await seed(old.items, count)
+  const oldStart = now()
+  await oldDestroyAllPermanently(old.items)
+  const oldMs = now() - oldStart
+
+  const fresh = await getDb('new')
+  await reset(fresh.database)
+  await seed(fresh.items, count)
+  const newStart = now()
+  await newDestroyAllPermanently(fresh.items)
+  const newMs = now() - newStart
+
+  return { count, oldMs, newMs }
+}

--- a/examples/benchmark/shared/BenchmarkScreen.tsx
+++ b/examples/benchmark/shared/BenchmarkScreen.tsx
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar'
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState, type ReactNode } from 'react'
 import {
   Pressable,
   ScrollView,
@@ -33,6 +33,10 @@ type Props = {
   adapter: BenchmarkAdapter | null
   setupError: string | null
   theme: BenchmarkTheme
+  // Rendered below the main write/query/delete comparison, for engine-specific extra
+  // benchmarks (e.g. NitromelonDB's mass-delete-implementation comparison) that don't belong
+  // in this shared, engine-agnostic screen.
+  children?: ReactNode
 }
 
 const idleProgress = (workload: BenchmarkWorkload): BenchmarkProgress => ({
@@ -46,7 +50,7 @@ const idleProgress = (workload: BenchmarkWorkload): BenchmarkProgress => ({
   roundsCompleted: [],
 })
 
-export function BenchmarkScreen({ title, subtitle, adapter, setupError, theme }: Props) {
+export function BenchmarkScreen({ title, subtitle, adapter, setupError, theme, children }: Props) {
   const [workload, setWorkload] = useState<BenchmarkWorkload>(FULL_WORKLOAD)
   const [running, setRunning] = useState(false)
   const [progress, setProgress] = useState<BenchmarkProgress>(() => idleProgress(FULL_WORKLOAD))
@@ -185,6 +189,8 @@ export function BenchmarkScreen({ title, subtitle, adapter, setupError, theme }:
             ))}
           </View>
         ) : null}
+
+        {children}
       </ScrollView>
       <StatusBar style="light" />
     </View>

--- a/examples/benchmark/watermelondb_benchmark/App.tsx
+++ b/examples/benchmark/watermelondb_benchmark/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { BenchmarkScreen } from '../shared/BenchmarkScreen'
 import { createWatermelonAdapter } from './database'
+import { MassDeleteBenchmarkCard } from './MassDeleteBenchmarkCard'
 
 const theme = {
   background: '#0b1210',
@@ -31,6 +32,8 @@ export default function App() {
       adapter={session.ok ? session.adapter : null}
       setupError={session.ok ? null : session.message}
       theme={theme}
-    />
+    >
+      <MassDeleteBenchmarkCard theme={theme} />
+    </BenchmarkScreen>
   )
 }

--- a/examples/benchmark/watermelondb_benchmark/MassDeleteBenchmarkCard.tsx
+++ b/examples/benchmark/watermelondb_benchmark/MassDeleteBenchmarkCard.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import type { BenchmarkTheme } from '../shared/BenchmarkScreen'
+import { formatNumber } from '../shared/format'
+import { runMassDeleteBenchmark, type MassDeleteResult } from './massDeleteBenchmark'
+
+const SIZES = [1_000, 5_000, 20_000]
+
+function formatMs(ms: number): string {
+  return `${ms.toFixed(1)}ms`
+}
+
+type Props = {
+  theme: BenchmarkTheme
+}
+
+// Reference point for the sibling NitromelonDB app's "Mass delete: old vs new" card: upstream
+// WatermelonDB has no destroyMatching() equivalent, so this just times what
+// Query#destroyAllPermanently() has always done here (one database.batch() call per matching
+// record), at the same record counts, so the two cards are directly comparable.
+export function MassDeleteBenchmarkCard({ theme }: Props) {
+  const [size, setSize] = useState(SIZES[1]!)
+  const [running, setRunning] = useState(false)
+  const [results, setResults] = useState<MassDeleteResult[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const styles = createStyles(theme)
+
+  const run = async () => {
+    if (running) {
+      return
+    }
+    setRunning(true)
+    setError(null)
+    try {
+      const result = await runMassDeleteBenchmark(size)
+      setResults((current) => [result, ...current])
+    } catch (runError) {
+      setError(runError instanceof Error ? runError.message : String(runError))
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>Mass delete (reference)</Text>
+      <Text style={styles.hint}>
+        WatermelonDB's Query#destroyAllPermanently(): one transaction per matching record -- this
+        is the number the NitromelonDB app's "old" column should roughly match, and what its "new"
+        column improves on. Each run seeds {formatNumber(size)} rows and times destroying all of
+        them.
+      </Text>
+
+      <View style={styles.sizeRow}>
+        {SIZES.map((candidate) => (
+          <Pressable
+            key={candidate}
+            style={[styles.chip, size === candidate && styles.chipActive, running && styles.disabled]}
+            onPress={() => setSize(candidate)}
+            disabled={running}
+          >
+            <Text style={[styles.chipLabel, size === candidate && styles.chipLabelActive]}>
+              {formatNumber(candidate)}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Pressable
+        style={[styles.button, running && styles.disabled]}
+        onPress={() => void run()}
+        disabled={running}
+      >
+        <Text style={styles.buttonLabel}>{running ? 'Running…' : 'Run'}</Text>
+      </Pressable>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      {results.length > 0 ? (
+        <View style={styles.table}>
+          <View style={styles.tableHeader}>
+            <Text style={[styles.tableCell, styles.tableWide]}>Records</Text>
+            <Text style={styles.tableCell}>Time</Text>
+          </View>
+          {results.map((result, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <View key={index} style={styles.tableRow}>
+              <Text style={[styles.tableCell, styles.tableWide]}>{formatNumber(result.count)}</Text>
+              <Text style={styles.tableCell}>{formatMs(result.ms)}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+function createStyles(theme: BenchmarkTheme) {
+  return StyleSheet.create({
+    card: {
+      marginTop: 20,
+      backgroundColor: theme.card,
+      borderRadius: 16,
+      padding: 16,
+    },
+    cardTitle: {
+      color: theme.muted,
+      fontSize: 13,
+      fontWeight: '700',
+      letterSpacing: 0.6,
+      textTransform: 'uppercase',
+      marginBottom: 8,
+    },
+    hint: {
+      color: theme.muted,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    sizeRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 8,
+      marginTop: 14,
+    },
+    chip: {
+      borderWidth: 1,
+      borderColor: '#3f3f46',
+      borderRadius: 999,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+    },
+    chipActive: {
+      backgroundColor: theme.accent,
+      borderColor: theme.accent,
+    },
+    chipLabel: {
+      color: theme.muted,
+      fontSize: 13,
+      fontWeight: '600',
+    },
+    chipLabelActive: {
+      color: theme.accentText,
+    },
+    button: {
+      marginTop: 14,
+      backgroundColor: theme.accent,
+      borderRadius: 12,
+      paddingVertical: 12,
+      alignItems: 'center',
+    },
+    buttonLabel: {
+      color: theme.accentText,
+      fontSize: 15,
+      fontWeight: '700',
+    },
+    disabled: {
+      opacity: 0.45,
+    },
+    error: {
+      marginTop: 10,
+      color: theme.danger,
+      fontSize: 13,
+      lineHeight: 18,
+    },
+    table: {
+      marginTop: 14,
+    },
+    tableHeader: {
+      flexDirection: 'row',
+      paddingBottom: 8,
+      borderBottomWidth: 1,
+      borderBottomColor: '#27272a',
+    },
+    tableRow: {
+      flexDirection: 'row',
+      paddingVertical: 8,
+      borderBottomWidth: 1,
+      borderBottomColor: '#18181b',
+    },
+    tableCell: {
+      flex: 1,
+      color: theme.text,
+      fontSize: 12,
+      fontVariant: ['tabular-nums'],
+    },
+    tableWide: {
+      flex: 1.4,
+    },
+  })
+}

--- a/examples/benchmark/watermelondb_benchmark/massDeleteBenchmark.ts
+++ b/examples/benchmark/watermelondb_benchmark/massDeleteBenchmark.ts
@@ -1,0 +1,79 @@
+import { Database } from '@nozbe/watermelondb'
+import type { Collection } from '@nozbe/watermelondb'
+import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite'
+import Item from './model/Item'
+import { ITEMS_TABLE, schema } from './model/schema'
+
+// Reference point for NitromelonDB's "Mass delete: old vs new" card (see the sibling
+// nitromelondb_benchmark app): plain upstream WatermelonDB has no destroyMatching()
+// equivalent, so this just times what Query#destroyAllPermanently() has always done here --
+// one database.batch() call (one adapter transaction) per matching record. Same shape (record
+// counts, seeding) as the NitromelonDB card's "old" column, so the two are directly comparable.
+
+export type MassDeleteResult = {
+  count: number
+  ms: number
+}
+
+type ItemDatabase = { database: Database; items: Collection<Item> }
+
+function now(): number {
+  return globalThis.performance?.now?.() ?? Date.now()
+}
+
+async function makeDatabase(): Promise<ItemDatabase> {
+  const adapter = new SQLiteAdapter({ schema, dbName: 'watermelon-massdelete', jsi: true })
+  const database = new Database({ adapter, modelClasses: [Item] })
+  return { database, items: database.get<Item>(ITEMS_TABLE) }
+}
+
+async function reset(database: Database): Promise<void> {
+  await database.write(() => database.unsafeResetDatabase())
+}
+
+async function seed(items: Collection<Item>, count: number): Promise<void> {
+  await items.database.write(async () => {
+    const operations = []
+    for (let index = 0; index < count; index += 1) {
+      operations.push(
+        items.prepareCreate((item) => {
+          item.title = `item-${index}`
+          item.value = index % 1000
+          item.createdAt = index
+        }),
+      )
+    }
+    await items.database.batch(operations)
+  })
+}
+
+// WatermelonDB's own destroyAllPermanently(): fetches full Model instances, then destroys each
+// one via its own database.batch() call -- one adapter transaction per record. Unlike
+// NitromelonDB, this is simply what the method does -- there's no faster path to compare it to
+// here.
+async function destroyAllPermanently(items: Collection<Item>): Promise<void> {
+  const records = await items.query().fetch()
+  await items.database.write(async () => {
+    for (const record of records) {
+      // eslint-disable-next-line no-await-in-loop
+      await items.database.batch(record.prepareDestroyPermanently())
+    }
+  })
+}
+
+let db: ItemDatabase | null = null
+
+async function getDb(): Promise<ItemDatabase> {
+  db ??= await makeDatabase()
+  return db
+}
+
+export async function runMassDeleteBenchmark(count: number): Promise<MassDeleteResult> {
+  const { database, items } = await getDb()
+  await reset(database)
+  await seed(items, count)
+  const started = now()
+  await destroyAllPermanently(items)
+  const ms = now() - started
+  return { count, ms }
+}

--- a/native/nitro/HybridNitromelonDatabase.cpp
+++ b/native/nitro/HybridNitromelonDatabase.cpp
@@ -335,6 +335,13 @@ void HybridNitromelonDatabase::batch(
   database().batch(cppOps);
 }
 
+std::vector<std::string> HybridNitromelonDatabase::destroyMatching(const std::string& table, const std::string& sql,
+                                                                    const std::vector<NitroSqliteValue>& args,
+                                                                    bool permanently, bool isUnconditional) {
+  assert(initialized_);
+  return database().destroyMatching(table, sql, toSqliteArgs(args), permanently, isUnconditional);
+}
+
 void HybridNitromelonDatabase::batchJSON(const std::string& operations) {
   assert(initialized_);
   database().batchJSON(operations);

--- a/native/nitro/HybridNitromelonDatabase.hpp
+++ b/native/nitro/HybridNitromelonDatabase.hpp
@@ -36,6 +36,9 @@ public:
   void batch(const std::vector<std::tuple<double, std::optional<std::variant<nitro::NullType, std::string>>, std::string,
                                           std::vector<std::vector<std::variant<nitro::NullType, bool, std::string, double>>>>>&
                  operations) override;
+  std::vector<std::string> destroyMatching(const std::string& table, const std::string& sql,
+                                           const std::vector<std::variant<nitro::NullType, bool, std::string, double>>& args,
+                                           bool permanently, bool isUnconditional) override;
   void batchJSON(const std::string& operations) override;
   std::variant<nitro::NullType, std::string> getLocal(const std::string& key) override;
   std::shared_ptr<AnyMap> unsafeLoadFromSync(double jsonId, const std::shared_ptr<AnyMap>& schema,

--- a/native/shared/Database-batch.cpp
+++ b/native/shared/Database-batch.cpp
@@ -157,4 +157,64 @@ void Database::batchJSON(jsi::String &&jsiJson) {
     batchJSON(jsiJson.utf8(getRt()));
 }
 
+// Powers Query#markAllAsDeleted()/destroyAllPermanently(). `sql`/`args` are exactly what would
+// otherwise be passed to queryIds() for this same Query -- reused here twice: once as-is, to
+// collect which ids match (identical loop to queryIds() above), and, when there IS a predicate
+// (`!isUnconditional`), a second time wrapped as an inline derived table inside the actual
+// DELETE/UPDATE (`where "id" in (select "id" from (<sql>))`), so no `WHERE id IN (?,?,…)`
+// argument list ever needs to be built (and chunked around SQLite's bound-parameter limit) here,
+// and no separate id-based batch call needs to cross the JS bridge at all. When there's no
+// predicate at all (a plain "delete/mark-delete everything" call, e.g. `collection.query()
+// .destroyAllPermanently()`), skips straight to a bare `delete from`/`update ... set` -- letting
+// SQLite's own truncate optimization deallocate whole pages instead of visiting every row, which
+// the `WHERE id IN (subquery)` form could never trigger even when the subquery matches every row.
+std::vector<std::string> Database::destroyMatching(const std::string &table, const std::string &sql,
+                                                    const std::vector<SqliteValue> &args, bool permanently,
+                                                    bool isUnconditional) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    beginTransaction();
+
+    std::vector<std::string> ids;
+
+    try {
+        auto statement = executeQuery(sql, args);
+        while (true) {
+            if (getNextRowOrTrue(statement.stmt)) {
+                break;
+            }
+            assert(std::string(sqlite3_column_name(statement.stmt, 0)) == "id");
+            const char *id = reinterpret_cast<const char *>(sqlite3_column_text(statement.stmt, 0));
+            if (!id) {
+                throw std::runtime_error("Failed to get ID of a record");
+            }
+            ids.emplace_back(id);
+        }
+
+        if (!ids.empty()) {
+            if (isUnconditional) {
+                executeUpdate(permanently ? "delete from `" + table + "`"
+                                          : "update `" + table + "` set `_status` = 'deleted'");
+            } else {
+                std::string mutationSql =
+                    permanently
+                        ? "delete from `" + table + "` where `id` in (select `id` from (" + sql + "))"
+                        : "update `" + table + "` set `_status` = 'deleted' where `id` in (select `id` from (" +
+                              sql + "))";
+                executeUpdate(mutationSql, args);
+            }
+        }
+
+        commit();
+    } catch (const std::exception &ex) {
+        rollback();
+        throw;
+    }
+
+    for (auto const &id : ids) {
+        removeFromCache(cacheKey(table, id));
+    }
+
+    return ids;
+}
+
 } // namespace watermelondb

--- a/native/shared/Database.h
+++ b/native/shared/Database.h
@@ -125,6 +125,7 @@ public:
     std::vector<SqliteRow> unsafeQueryRaw(const std::string &sql, const std::vector<SqliteValue> &arguments);
     double count(const std::string &sql, const std::vector<SqliteValue> &arguments);
     void batch(const std::vector<SqliteBatchOperation> &operations);
+    std::vector<std::string> destroyMatching(const std::string &table, const std::string &sql, const std::vector<SqliteValue> &args, bool permanently, bool isUnconditional);
     void batchJSON(const std::string &operationsJson);
     std::unordered_map<std::string, std::string> loadFromSync(int jsonId, const SyncSchema &schema, std::string preamble, std::string postamble);
     void unsafeResetDatabase(const std::string &schema, int schemaVersion);

--- a/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.cpp
@@ -24,6 +24,7 @@ namespace margelo::nitro::watermelondb {
       prototype.registerHybridMethod("unsafeQueryRaw", &HybridNitromelonDatabaseSpec::unsafeQueryRaw);
       prototype.registerHybridMethod("count", &HybridNitromelonDatabaseSpec::count);
       prototype.registerHybridMethod("batch", &HybridNitromelonDatabaseSpec::batch);
+      prototype.registerHybridMethod("destroyMatching", &HybridNitromelonDatabaseSpec::destroyMatching);
       prototype.registerHybridMethod("batchJSON", &HybridNitromelonDatabaseSpec::batchJSON);
       prototype.registerHybridMethod("getLocal", &HybridNitromelonDatabaseSpec::getLocal);
       prototype.registerHybridMethod("unsafeLoadFromSync", &HybridNitromelonDatabaseSpec::unsafeLoadFromSync);

--- a/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitromelonDatabaseSpec.hpp
@@ -67,6 +67,7 @@ namespace margelo::nitro::watermelondb {
       virtual std::vector<std::shared_ptr<AnyMap>> unsafeQueryRaw(const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::string, double>>& args) = 0;
       virtual double count(const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::string, double>>& args) = 0;
       virtual void batch(const std::vector<std::tuple<double, std::optional<std::variant<nitro::NullType, std::string>>, std::string, std::vector<std::vector<std::variant<nitro::NullType, bool, std::string, double>>>>>& operations) = 0;
+      virtual std::vector<std::string> destroyMatching(const std::string& table, const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::string, double>>& args, bool permanently, bool isUnconditional) = 0;
       virtual void batchJSON(const std::string& operations) = 0;
       virtual std::variant<nitro::NullType, std::string> getLocal(const std::string& key) = 0;
       virtual std::shared_ptr<AnyMap> unsafeLoadFromSync(double jsonId, const std::shared_ptr<AnyMap>& schema, const std::string& preamble, const std::string& postamble) = 0;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:workflows": "node scripts/lint-workflows.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "jest --config=./jest.config.js --forceExit",
+    "benchmark:destroy-all": "jest --config=./jest.config.js --forceExit --testMatch '**/destroyAll.benchmark.js'",
     "test:web": "yarn --cwd examples/NotesApp test:web",
     "ci": "yarn ci:check",
     "test:metro-transform": "node ./scripts/check-metro-transform.mjs",

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -519,13 +519,12 @@ export default class Database {
   // Powers Query#markAllAsDeleted()/destroyAllPermanently(). Delegates the actual matching AND
   // mutating to a single adapter.destroyMatching() call -- one native/engine-level operation that
   // resolves the query, deletes/marks-deleted every matching row, and returns just the affected
-  // ids -- rather than resolving ids here (Query#fetchIds()) and then batching a mutation per id
-  // (see git history for that intermediate design): a full row SELECT/DELETE-by-id loop is real,
+  // ids. See each DatabaseAdapter's destroyMatching() implementation (e.g.
+  // native/shared/Database-batch.cpp's Database::destroyMatching) for why that beats resolving
+  // ids here and batching a mutation per id -- in short, a full row SELECT/DELETE-by-id loop is
   // avoidable work when most matching rows were never loaded into memory to begin with, and (for
-  // an unconditional "clear the whole table" query) throwing away SQLite's own truncate
-  // optimization is real, avoidable slowness too. See each DatabaseAdapter's destroyMatching()
-  // implementation (e.g. native/shared/Database-batch.cpp's Database::destroyMatching) for the
-  // full reasoning.
+  // an unconditional "clear the whole table" query) it throws away SQLite's own truncate
+  // optimization.
   //
   // What we still must do here in JS: only ids already resident in the collection's RecordCache
   // (i.e. some Model instance for them already exists, so *something* might be holding a

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -6,6 +6,7 @@ import { noop, fromArrayOrSpread } from '../utils/fp'
 import type { DatabaseAdapter, BatchOperation } from '../adapters/type'
 import DatabaseAdapterCompat from '../adapters/compat'
 import type Model from '../Model'
+import type { RecordId } from '../Model'
 import type Collection from '../Collection'
 import type { CollectionChangeSet, ModelClass } from '../Collection'
 import type { TableName, AppSchema, SchemaVersion } from '../Schema'
@@ -513,6 +514,61 @@ export default class Database {
     this._notify(changes)
 
     return undefined // shuts up flow
+  }
+
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). Deliberately bypasses _performBatch's
+  // Model-based path: those ids came from Query#fetchIds(), a bare `select id` that (unlike
+  // fetch()) never touches the JS RecordCache or the native/adapter-side "already sent to JS"
+  // cache (see native/shared/Database-query.cpp's queryIds()). Building a full Model for every id
+  // here just to immediately destroy it would mean paying for a full row fetch, RawRecord
+  // sanitization and a cache insert -- for every single row -- purely to undo it a moment later.
+  //
+  // Instead: only ids already resident in the collection's RecordCache (i.e. some Model instance
+  // for them already exists, so *something* might be holding a reference to it) go through the
+  // real record.prepareMarkAsDeleted()/prepareDestroyPermanently(), so that instance is properly
+  // evicted from the cache and any of its own subscribers (record.experimentalSubscribe(),
+  // Model#observe()) are notified. Records nobody has ever fetched can't be referenced by any
+  // per-record observer (processChangeSet.ts matches destroyed records by identity against the
+  // Model instances a query previously handed out -- see also Collection._cache's own note on
+  // why that identity must come from this same cache), so for those we skip Model construction
+  // and go straight to a raw adapter op. Table-level observers (Query#observe/observeCount, which
+  // don't key off specific record identity -- see subscribeToCount/subscribeToQueryReloading)
+  // still fire correctly either way, since _notify() below always includes `table`.
+  async _performMassDestroy(
+    table: TableName,
+    ids: RecordId[],
+    type: 'markAsDeleted' | 'destroyPermanently',
+  ): Promise<void> {
+    this._ensureInWriter(
+      `Query#${type === 'destroyPermanently' ? 'destroyAllPermanently' : 'markAllAsDeleted'}()`,
+    )
+
+    if (!ids.length) {
+      return
+    }
+
+    const collection = this.collections.get(table)
+    const batchOperations: BatchOperation[] = new Array(ids.length)
+    const changeSet: CollectionChangeSet<Model> = []
+
+    ids.forEach((id, i) => {
+      batchOperations[i] = [type, table, id]
+
+      const cachedRecord = collection._cache.get(id)
+      if (cachedRecord) {
+        type === 'destroyPermanently'
+          ? cachedRecord.prepareDestroyPermanently()
+          : cachedRecord.prepareMarkAsDeleted()
+        // See _performBatch above for why this is reset eagerly
+        cachedRecord._preparedState = null
+        changeSet.push({ record: cachedRecord, type: 'destroyed' })
+      }
+    })
+
+    await this.adapter.batch(batchOperations)
+
+    collection._applyChangesToCache(changeSet)
+    this._notify([[table, changeSet]])
   }
 
   _pendingNotificationBatches: number = 0

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -6,7 +6,7 @@ import { noop, fromArrayOrSpread } from '../utils/fp'
 import type { DatabaseAdapter, BatchOperation } from '../adapters/type'
 import DatabaseAdapterCompat from '../adapters/compat'
 import type Model from '../Model'
-import type { RecordId } from '../Model'
+import type { SerializedQuery } from '../Query'
 import type Collection from '../Collection'
 import type { CollectionChangeSet, ModelClass } from '../Collection'
 import type { TableName, AppSchema, SchemaVersion } from '../Schema'
@@ -516,44 +516,47 @@ export default class Database {
     return undefined // shuts up flow
   }
 
-  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). Deliberately bypasses _performBatch's
-  // Model-based path: those ids came from Query#fetchIds(), a bare `select id` that (unlike
-  // fetch()) never touches the JS RecordCache or the native/adapter-side "already sent to JS"
-  // cache (see native/shared/Database-query.cpp's queryIds()). Building a full Model for every id
-  // here just to immediately destroy it would mean paying for a full row fetch, RawRecord
-  // sanitization and a cache insert -- for every single row -- purely to undo it a moment later.
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). Delegates the actual matching AND
+  // mutating to a single adapter.destroyMatching() call -- one native/engine-level operation that
+  // resolves the query, deletes/marks-deleted every matching row, and returns just the affected
+  // ids -- rather than resolving ids here (Query#fetchIds()) and then batching a mutation per id
+  // (see git history for that intermediate design): a full row SELECT/DELETE-by-id loop is real,
+  // avoidable work when most matching rows were never loaded into memory to begin with, and (for
+  // an unconditional "clear the whole table" query) throwing away SQLite's own truncate
+  // optimization is real, avoidable slowness too. See each DatabaseAdapter's destroyMatching()
+  // implementation (e.g. native/shared/Database-batch.cpp's Database::destroyMatching) for the
+  // full reasoning.
   //
-  // Instead: only ids already resident in the collection's RecordCache (i.e. some Model instance
-  // for them already exists, so *something* might be holding a reference to it) go through the
-  // real record.prepareMarkAsDeleted()/prepareDestroyPermanently(), so that instance is properly
-  // evicted from the cache and any of its own subscribers (record.experimentalSubscribe(),
-  // Model#observe()) are notified. Records nobody has ever fetched can't be referenced by any
-  // per-record observer (processChangeSet.ts matches destroyed records by identity against the
-  // Model instances a query previously handed out -- see also Collection._cache's own note on
-  // why that identity must come from this same cache), so for those we skip Model construction
-  // and go straight to a raw adapter op. Table-level observers (Query#observe/observeCount, which
+  // What we still must do here in JS: only ids already resident in the collection's RecordCache
+  // (i.e. some Model instance for them already exists, so *something* might be holding a
+  // reference to it) go through the real record.prepareMarkAsDeleted()/prepareDestroyPermanently(),
+  // so that instance is properly evicted from the cache and any of its own subscribers
+  // (record.experimentalSubscribe(), Model#observe()) are notified. Records nobody has ever
+  // fetched can't be referenced by any per-record observer (processChangeSet.ts matches destroyed
+  // records by identity against the Model instances a query previously handed out -- see also
+  // Collection._cache's own note on why that identity must come from this same cache), so for
+  // those there's nothing further to do. Table-level observers (Query#observe/observeCount, which
   // don't key off specific record identity -- see subscribeToCount/subscribeToQueryReloading)
   // still fire correctly either way, since _notify() below always includes `table`.
   async _performMassDestroy(
-    table: TableName,
-    ids: RecordId[],
+    query: SerializedQuery,
     type: 'markAsDeleted' | 'destroyPermanently',
   ): Promise<void> {
     this._ensureInWriter(
       `Query#${type === 'destroyPermanently' ? 'destroyAllPermanently' : 'markAllAsDeleted'}()`,
     )
 
+    const { table } = query
+    const ids = await this.adapter.destroyMatching(query, type === 'destroyPermanently')
+
     if (!ids.length) {
       return
     }
 
     const collection = this.collections.get(table)
-    const batchOperations: BatchOperation[] = new Array(ids.length)
     const changeSet: CollectionChangeSet<Model> = []
 
-    ids.forEach((id, i) => {
-      batchOperations[i] = [type, table, id]
-
+    ids.forEach((id) => {
       const cachedRecord = collection._cache.get(id)
       if (cachedRecord) {
         type === 'destroyPermanently'
@@ -564,8 +567,6 @@ export default class Database {
         changeSet.push({ record: cachedRecord, type: 'destroyed' })
       }
     })
-
-    await this.adapter.batch(batchOperations)
 
     collection._applyChangesToCache(changeSet)
     this._notify([[table, changeSet]])

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -1,4 +1,3 @@
-import allPromises from '../utils/fp/allPromises'
 import invariant from '../utils/common/invariant'
 import { Observable, type Observer } from '../utils/rx'
 import { toPromise } from '../utils/fp/Result'
@@ -329,17 +328,33 @@ export default class Query<Record extends Model> {
   /**
    * Marks all records matching this query as deleted (they will be deleted permenantly after sync)
    *
+   * Unlike calling `markAsDeleted()` on each record individually, this issues a single
+   * `database.batch()` call (one underlying adapter transaction) for every matching record,
+   * regardless of how many there are -- the same trick `destroyAllPermanently()` uses, see there
+   * for why that matters.
+   *
    * Note: This method must be called within a Writer {@link Database#write}.
    *
    * @see {Model#markAsDeleted}
    */
   async markAllAsDeleted(): Promise<void> {
     const records = await this.fetch()
-    await allPromises((record) => record.markAsDeleted(), records)
+    await this.collection.database.batch(records.map((record) => record.prepareMarkAsDeleted()))
   }
 
   /**
    * Permanently deletes all records matching this query
+   *
+   * This is the right way to clear a whole table (or a subset of it): pass a query with no
+   * conditions to delete everything, or add `Q.where`/`Q.notEq`/`Q.notIn` clauses to exclude
+   * specific records. Unlike raw/unsafe SQL, this keeps the in-memory record cache and any
+   * active observers (`.observe()`, `experimentalSubscribe()`, etc.) correctly up to date --
+   * see `Database#unsafeExecute()`/`adapter.unsafeExecute()` for why a raw `DELETE` doesn't.
+   *
+   * Internally this calls `record.prepareDestroyPermanently()` on every matching record and
+   * commits them all via a single `database.batch()` call, so it's one adapter transaction
+   * (see `DatabaseAdapter#batch`) no matter how many records match -- not one transaction per
+   * record, which is what calling `destroyPermanently()` on each record in a loop would do.
    *
    * Note: Do not use this when using Sync, as deletion will not be synced.
    *
@@ -349,7 +364,9 @@ export default class Query<Record extends Model> {
    */
   async destroyAllPermanently(): Promise<void> {
     const records = await this.fetch()
-    await allPromises((record) => record.destroyPermanently(), records)
+    await this.collection.database.batch(
+      records.map((record) => record.prepareDestroyPermanently()),
+    )
   }
 
   // MARK: - Internals

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -328,18 +328,17 @@ export default class Query<Record extends Model> {
   /**
    * Marks all records matching this query as deleted (they will be deleted permenantly after sync)
    *
-   * This commits a single `database.batch()` call (one underlying adapter transaction) no matter
-   * how many records match, and only builds a `Model` for a matching record if one is already
-   * cached (i.e. something might be observing it) -- see `destroyAllPermanently()` for why that
-   * matters and why it's still fully correct.
+   * This resolves and mutates matching records in a single `adapter.destroyMatching()` call (one
+   * native/engine-level operation) no matter how many records match, and only builds a `Model`
+   * for a matching record if one is already cached (i.e. something might be observing it) -- see
+   * `destroyAllPermanently()` for why that matters and why it's still fully correct.
    *
    * Note: This method must be called within a Writer {@link Database#write}.
    *
    * @see {Model#markAsDeleted}
    */
   async markAllAsDeleted(): Promise<void> {
-    const ids = await this.fetchIds()
-    await this.collection.database._performMassDestroy(this.table, ids, 'markAsDeleted')
+    await this.collection.database._performMassDestroy(this.serialize(), 'markAsDeleted')
   }
 
   /**
@@ -351,13 +350,18 @@ export default class Query<Record extends Model> {
    * active observers (`.observe()`, `.observeCount()`, etc.) correctly up to date -- see
    * `Database#unsafeExecute()`/`adapter.unsafeExecute()` for why a raw `DELETE` doesn't.
    *
-   * This uses `fetchIds()` rather than `fetch()`, and commits every matching id in a single
-   * `database.batch()` call (one adapter transaction, see `DatabaseAdapter#batch`) regardless of
-   * how many records match. A full `Model` is only built for an id that's already cached (i.e.
-   * something might hold a reference to it, e.g. via `.observe()`) -- building one for every
-   * matching row just to immediately destroy it would mean a full row fetch and cache insert per
-   * row, purely to undo it a moment later. See `Database#_performMassDestroy` for the full
-   * reasoning, including why this stays correct for every active observer.
+   * This resolves which records match AND deletes them in a single `adapter.destroyMatching()`
+   * call -- one native/engine-level operation (e.g. one SQL statement) regardless of how many
+   * records match, rather than first fetching ids in JS and then batching a mutation per id. For
+   * a query with no conditions at all (delete the whole table), this also lets the underlying
+   * engine skip straight to an unconditional delete, unlocking optimizations (like SQLite's own
+   * page-truncation fast path) that a per-id `WHERE id IN (...)` could never trigger. A full
+   * `Model` is only built for an id that's already cached (i.e. something might hold a reference
+   * to it, e.g. via `.observe()`) -- building one for every matching row just to immediately
+   * destroy it would mean a full row fetch and cache insert per row, purely to undo it a moment
+   * later. See `Database#_performMassDestroy` and each `DatabaseAdapter#destroyMatching`
+   * implementation for the full reasoning, including why this stays correct for every active
+   * observer.
    *
    * Note: Do not use this when using Sync, as deletion will not be synced.
    *
@@ -366,8 +370,7 @@ export default class Query<Record extends Model> {
    * @see {Model#destroyPermanently}
    */
   async destroyAllPermanently(): Promise<void> {
-    const ids = await this.fetchIds()
-    await this.collection.database._performMassDestroy(this.table, ids, 'destroyPermanently')
+    await this.collection.database._performMassDestroy(this.serialize(), 'destroyPermanently')
   }
 
   // MARK: - Internals

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -328,10 +328,9 @@ export default class Query<Record extends Model> {
   /**
    * Marks all records matching this query as deleted (they will be deleted permenantly after sync)
    *
-   * This resolves and mutates matching records in a single `adapter.destroyMatching()` call (one
-   * native/engine-level operation) no matter how many records match, and only builds a `Model`
-   * for a matching record if one is already cached (i.e. something might be observing it) -- see
-   * `destroyAllPermanently()` for why that matters and why it's still fully correct.
+   * Resolves and mutates matching records in a single operation, regardless of how many records
+   * match -- see {@link Database#_performMassDestroy} for the mechanism, shared with
+   * {@link Query#destroyAllPermanently}.
    *
    * Note: This method must be called within a Writer {@link Database#write}.
    *
@@ -350,18 +349,9 @@ export default class Query<Record extends Model> {
    * active observers (`.observe()`, `.observeCount()`, etc.) correctly up to date -- see
    * `Database#unsafeExecute()`/`adapter.unsafeExecute()` for why a raw `DELETE` doesn't.
    *
-   * This resolves which records match AND deletes them in a single `adapter.destroyMatching()`
-   * call -- one native/engine-level operation (e.g. one SQL statement) regardless of how many
-   * records match, rather than first fetching ids in JS and then batching a mutation per id. For
-   * a query with no conditions at all (delete the whole table), this also lets the underlying
-   * engine skip straight to an unconditional delete, unlocking optimizations (like SQLite's own
-   * page-truncation fast path) that a per-id `WHERE id IN (...)` could never trigger. A full
-   * `Model` is only built for an id that's already cached (i.e. something might hold a reference
-   * to it, e.g. via `.observe()`) -- building one for every matching row just to immediately
-   * destroy it would mean a full row fetch and cache insert per row, purely to undo it a moment
-   * later. See `Database#_performMassDestroy` and each `DatabaseAdapter#destroyMatching`
-   * implementation for the full reasoning, including why this stays correct for every active
-   * observer.
+   * Resolves and mutates matching records in a single operation, regardless of how many records
+   * match -- see {@link Database#_performMassDestroy} for the mechanism, and each
+   * `DatabaseAdapter#destroyMatching` implementation for how each backend does it.
    *
    * Note: Do not use this when using Sync, as deletion will not be synced.
    *

--- a/src/Query/index.ts
+++ b/src/Query/index.ts
@@ -328,18 +328,18 @@ export default class Query<Record extends Model> {
   /**
    * Marks all records matching this query as deleted (they will be deleted permenantly after sync)
    *
-   * Unlike calling `markAsDeleted()` on each record individually, this issues a single
-   * `database.batch()` call (one underlying adapter transaction) for every matching record,
-   * regardless of how many there are -- the same trick `destroyAllPermanently()` uses, see there
-   * for why that matters.
+   * This commits a single `database.batch()` call (one underlying adapter transaction) no matter
+   * how many records match, and only builds a `Model` for a matching record if one is already
+   * cached (i.e. something might be observing it) -- see `destroyAllPermanently()` for why that
+   * matters and why it's still fully correct.
    *
    * Note: This method must be called within a Writer {@link Database#write}.
    *
    * @see {Model#markAsDeleted}
    */
   async markAllAsDeleted(): Promise<void> {
-    const records = await this.fetch()
-    await this.collection.database.batch(records.map((record) => record.prepareMarkAsDeleted()))
+    const ids = await this.fetchIds()
+    await this.collection.database._performMassDestroy(this.table, ids, 'markAsDeleted')
   }
 
   /**
@@ -348,13 +348,16 @@ export default class Query<Record extends Model> {
    * This is the right way to clear a whole table (or a subset of it): pass a query with no
    * conditions to delete everything, or add `Q.where`/`Q.notEq`/`Q.notIn` clauses to exclude
    * specific records. Unlike raw/unsafe SQL, this keeps the in-memory record cache and any
-   * active observers (`.observe()`, `experimentalSubscribe()`, etc.) correctly up to date --
-   * see `Database#unsafeExecute()`/`adapter.unsafeExecute()` for why a raw `DELETE` doesn't.
+   * active observers (`.observe()`, `.observeCount()`, etc.) correctly up to date -- see
+   * `Database#unsafeExecute()`/`adapter.unsafeExecute()` for why a raw `DELETE` doesn't.
    *
-   * Internally this calls `record.prepareDestroyPermanently()` on every matching record and
-   * commits them all via a single `database.batch()` call, so it's one adapter transaction
-   * (see `DatabaseAdapter#batch`) no matter how many records match -- not one transaction per
-   * record, which is what calling `destroyPermanently()` on each record in a loop would do.
+   * This uses `fetchIds()` rather than `fetch()`, and commits every matching id in a single
+   * `database.batch()` call (one adapter transaction, see `DatabaseAdapter#batch`) regardless of
+   * how many records match. A full `Model` is only built for an id that's already cached (i.e.
+   * something might hold a reference to it, e.g. via `.observe()`) -- building one for every
+   * matching row just to immediately destroy it would mean a full row fetch and cache insert per
+   * row, purely to undo it a moment later. See `Database#_performMassDestroy` for the full
+   * reasoning, including why this stays correct for every active observer.
    *
    * Note: Do not use this when using Sync, as deletion will not be synced.
    *
@@ -363,10 +366,8 @@ export default class Query<Record extends Model> {
    * @see {Model#destroyPermanently}
    */
   async destroyAllPermanently(): Promise<void> {
-    const records = await this.fetch()
-    await this.collection.database.batch(
-      records.map((record) => record.prepareDestroyPermanently()),
-    )
+    const ids = await this.fetchIds()
+    await this.collection.database._performMassDestroy(this.table, ids, 'destroyPermanently')
   }
 
   // MARK: - Internals

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -458,6 +458,82 @@ describe('Query', () => {
     it('can destroy all permanently', async () => {
       await testMassDelete('destroyAllPermanently')
     })
+
+    const testMassDeleteAvoidsFullFetch = async (methodName) => {
+      const { database, tasks, cloneDatabase } = mockDatabase()
+
+      await database.write(() =>
+        database.batch(
+          tasks.prepareCreate((t) => {
+            t.name = 'foo'
+          }),
+          tasks.prepareCreate((t) => {
+            t.name = 'foo'
+          }),
+        ),
+      )
+
+      // Records created above are immediately cached in `tasks`'s RecordCache -- database.batch()
+      // adds them on 'created'. Simulate the common case of destroying records nobody has loaded
+      // into memory yet (e.g. right after an app start) via a fresh Database over the same
+      // (cloned) persisted data, which starts with an empty RecordCache.
+      const freshDatabase = await cloneDatabase()
+      const freshTasks = freshDatabase.collections.get('mock_tasks')
+      const freshQuery = new Query(freshTasks, [Q.where('name', 'foo')])
+
+      const querySpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'query')
+      const findSpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'find')
+      const batchSpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'batch')
+
+      await freshDatabase.write(() => freshQuery[methodName]())
+
+      // no full-row fetch for records nobody has loaded -- only the id-only queryIds() call
+      // (exercised via fetchIds()) plus the single destroy batch
+      expect(querySpy).not.toHaveBeenCalled()
+      expect(findSpy).not.toHaveBeenCalled()
+      expect(batchSpy).toHaveBeenCalledTimes(1)
+
+      expect(await freshQuery.fetchCount()).toBe(0)
+    }
+    it('marks all as deleted without fetching full records for ids nobody has cached', async () => {
+      await testMassDeleteAvoidsFullFetch('markAllAsDeleted')
+    })
+    it('destroys all permanently without fetching full records for ids nobody has cached', async () => {
+      await testMassDeleteAvoidsFullFetch('destroyAllPermanently')
+    })
+
+    const testMassDeleteUpdatesLiveSubscription = async (methodName) => {
+      const { database, tasks } = mockDatabase()
+      const query = new Query(tasks, [Q.where('name', 'foo')])
+
+      await database.write(() =>
+        tasks.create((t) => {
+          t.name = 'foo'
+        }),
+      )
+
+      const observer = jest.fn()
+      const unsubscribe = query.experimentalSubscribe(observer)
+      await database.adapter.getLocal('nothing') // flush the queue, see waitFor() above
+
+      expect(observer).toHaveBeenCalledTimes(1)
+      expect(observer.mock.calls[0][0]).toHaveLength(1)
+
+      // this record is now cached (fetched above) -- destroying it must still remove it from the
+      // live subscription's own result list by identity, not just from the DB
+      await database.write(() => query[methodName]())
+
+      expect(observer).toHaveBeenCalledTimes(2)
+      expect(observer.mock.calls[1][0]).toHaveLength(0)
+
+      unsubscribe()
+    }
+    it('correctly updates a live subscription when marking an already-cached record as deleted', async () => {
+      await testMassDeleteUpdatesLiveSubscription('markAllAsDeleted')
+    })
+    it('correctly updates a live subscription when destroying an already-cached record permanently', async () => {
+      await testMassDeleteUpdatesLiveSubscription('destroyAllPermanently')
+    })
   })
 
   it(`has wmelon tag`, () => {

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -442,12 +442,14 @@ describe('Query', () => {
       expect(await queryAll.fetchCount()).toBe(5)
       expect(await query.fetchCount()).toBe(3)
 
-      const adapterBatchSpy = jest.spyOn(database.adapter.underlyingAdapter, 'batch')
+      const destroyMatchingSpy = jest.spyOn(database.adapter.underlyingAdapter, 'destroyMatching')
+      const batchSpy = jest.spyOn(database.adapter.underlyingAdapter, 'batch')
       await database.write(() => query[methodName]())
-      // regardless of how many records matched, this must be a single adapter.batch() call (one
-      // transaction) -- not one per record, which is what made bulk deletes slow enough that
-      // people reached for unsafe raw SQL instead
-      expect(adapterBatchSpy).toHaveBeenCalledTimes(1)
+      // regardless of how many records matched, this must be a single adapter.destroyMatching()
+      // call (one native/engine-level operation) -- not a per-record adapter.batch(), which is
+      // what made bulk deletes slow enough that people reached for unsafe raw SQL instead
+      expect(destroyMatchingSpy).toHaveBeenCalledTimes(1)
+      expect(batchSpy).not.toHaveBeenCalled()
 
       expect(await queryAll.fetchCount()).toBe(2)
       expect(await query.fetchCount()).toBe(0)
@@ -483,15 +485,19 @@ describe('Query', () => {
 
       const querySpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'query')
       const findSpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'find')
+      const queryIdsSpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'queryIds')
       const batchSpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'batch')
+      const destroyMatchingSpy = jest.spyOn(freshDatabase.adapter.underlyingAdapter, 'destroyMatching')
 
       await freshDatabase.write(() => freshQuery[methodName]())
 
-      // no full-row fetch for records nobody has loaded -- only the id-only queryIds() call
-      // (exercised via fetchIds()) plus the single destroy batch
+      // no full-row fetch for records nobody has loaded, and no separate id-resolution call or
+      // per-id batch either -- destroyMatching() resolves and mutates in one adapter call
       expect(querySpy).not.toHaveBeenCalled()
       expect(findSpy).not.toHaveBeenCalled()
-      expect(batchSpy).toHaveBeenCalledTimes(1)
+      expect(queryIdsSpy).not.toHaveBeenCalled()
+      expect(batchSpy).not.toHaveBeenCalled()
+      expect(destroyMatchingSpy).toHaveBeenCalledTimes(1)
 
       expect(await freshQuery.fetchCount()).toBe(0)
     }

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -441,7 +441,14 @@ describe('Query', () => {
       )
       expect(await queryAll.fetchCount()).toBe(5)
       expect(await query.fetchCount()).toBe(3)
+
+      const adapterBatchSpy = jest.spyOn(database.adapter.underlyingAdapter, 'batch')
       await database.write(() => query[methodName]())
+      // regardless of how many records matched, this must be a single adapter.batch() call (one
+      // transaction) -- not one per record, which is what made bulk deletes slow enough that
+      // people reached for unsafe raw SQL instead
+      expect(adapterBatchSpy).toHaveBeenCalledTimes(1)
+
       expect(await queryAll.fetchCount()).toBe(2)
       expect(await query.fetchCount()).toBe(0)
     }

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -341,6 +341,55 @@ export default () => {
     expect(await adapter.queryIds(taskQuery())).toEqual(['s1', 's2'])
     expect(await adapter.queryIds(taskQuery())).toEqual(['s1', 's2'])
   })
+  it('can permanently destroy records matching a query, without fetching them first', async (_adapter) => {
+    let adapter = _adapter
+    await adapter.batch([
+      ['create', 'tasks', mockTaskRaw({ id: 's1', order: 1, bool1: true })],
+      ['create', 'tasks', mockTaskRaw({ id: 's2', order: 2, bool1: true })],
+      ['create', 'tasks', mockTaskRaw({ id: 's3', order: 3, bool1: false })],
+    ])
+
+    // reload so nothing is cached in this adapter instance -- exercises the "nobody has fetched
+    // these records" path, not just the "records happen to already be cached" one
+    adapter = await adapter.testClone()
+
+    const destroyedIds = await adapter.destroyMatching(taskQuery(Q.where('bool1', true)), true)
+    expect(destroyedIds.slice().sort()).toEqual(['s1', 's2'])
+    expect(await adapter.queryIds(taskQuery())).toEqual(['s3'])
+
+    // destroying again (nothing left matching) is a safe no-op
+    expect(await adapter.destroyMatching(taskQuery(Q.where('bool1', true)), true)).toEqual([])
+  })
+  it('can mark records as deleted matching a query', async (_adapter) => {
+    let adapter = _adapter
+    await adapter.batch([
+      ['create', 'tasks', mockTaskRaw({ id: 's1', order: 1, bool1: true })],
+      ['create', 'tasks', mockTaskRaw({ id: 's2', order: 2, bool1: false })],
+    ])
+    adapter = await adapter.testClone()
+
+    const affectedIds = await adapter.destroyMatching(taskQuery(Q.where('bool1', true)), false)
+    expect(affectedIds).toEqual(['s1'])
+    // markAsDeleted records are excluded from ordinary queries (Q.queryWithoutDeleted)
+    expect(await adapter.queryIds(taskQuery())).toEqual(['s2'])
+    // but the row still physically exists, unlike a permanent destroy
+    expect(await adapter.getDeletedRecords('tasks')).toEqual(['s1'])
+  })
+  it('can destroy every record when the query has no conditions at all', async (_adapter) => {
+    let adapter = _adapter
+    await adapter.batch([
+      ['create', 'tasks', mockTaskRaw({ id: 's1' })],
+      ['create', 'tasks', mockTaskRaw({ id: 's2' })],
+    ])
+    adapter = await adapter.testClone()
+
+    const destroyedIds = await adapter.destroyMatching(taskQuery(), true)
+    expect(destroyedIds.slice().sort()).toEqual(['s1', 's2'])
+    expect(await adapter.queryIds(taskQuery())).toEqual([])
+  })
+  it('destroying matching returns an empty array when nothing matches', async (adapter) => {
+    expect(await adapter.destroyMatching(taskQuery(Q.where('text1', 'nope')), true)).toEqual([])
+  })
   it('can unsafely query raws with SQL', async (adapter, AdapterClass) => {
     await adapter.batch([
       ['create', 'tasks', mockTaskRaw({ id: 't1', order: 1, text1: 'hello' })],

--- a/src/adapters/__tests__/sqliteTests/batches.js
+++ b/src/adapters/__tests__/sqliteTests/batches.js
@@ -1,4 +1,5 @@
 /* eslint-disable jest/no-standalone-expect */
+import * as Q from '../../../QueryDescription'
 import { taskQuery } from '../helpers'
 import { createFileAdapter } from './helpers'
 
@@ -45,6 +46,50 @@ export default (it) => {
     const records = Array.from({ length: 1000 }, (_, i) => ({ id: `t${i}`, text1: `task ${i}` }))
     await adapter.batch(records.map((r) => ['create', 'tasks', r]))
     await adapter.batch(records.map((r) => ['destroyPermanently', 'tasks', r.id]))
+    expect(await adapter.count(taskQuery())).toBe(0)
+  })
+
+  it('large destroyMatching (10k records) removes only matching records', async (
+    _adapter,
+    AdapterClass,
+    _extra,
+    platform,
+  ) => {
+    if (AdapterClass.name === 'LokiJSAdapter') return
+
+    const { adapter } = await createFileAdapter(platform)
+
+    const records = Array.from({ length: 10000 }, (_, i) => ({
+      id: `t${i}`,
+      text1: `task ${i}`,
+      bool1: i % 3 === 0,
+    }))
+    await adapter.batch(records.map((r) => ['create', 'tasks', r]))
+    const matchingCount = records.filter((r) => r.bool1).length
+
+    const destroyedIds = await adapter.destroyMatching(taskQuery(Q.where('bool1', true)), true)
+
+    expect(destroyedIds).toHaveLength(matchingCount)
+    expect(await adapter.count(taskQuery(Q.where('bool1', true)))).toBe(0)
+    expect(await adapter.count(taskQuery())).toBe(records.length - matchingCount)
+  })
+
+  it('large destroyMatching with no conditions clears the whole table via one statement', async (
+    _adapter,
+    AdapterClass,
+    _extra,
+    platform,
+  ) => {
+    if (AdapterClass.name === 'LokiJSAdapter') return
+
+    const { adapter } = await createFileAdapter(platform)
+
+    const records = Array.from({ length: 10000 }, (_, i) => ({ id: `t${i}`, text1: `task ${i}` }))
+    await adapter.batch(records.map((r) => ['create', 'tasks', r]))
+
+    const destroyedIds = await adapter.destroyMatching(taskQuery(), true)
+
+    expect(destroyedIds).toHaveLength(records.length)
     expect(await adapter.count(taskQuery())).toBe(0)
   })
 

--- a/src/adapters/__tests__/sqliteTests/destroyAll.benchmark.js
+++ b/src/adapters/__tests__/sqliteTests/destroyAll.benchmark.js
@@ -1,0 +1,133 @@
+/* eslint-disable no-console */
+// Not picked up by `yarn jest`/`yarn test` (its name doesn't match jest.config.js's testMatch).
+// Run explicitly: `yarn benchmark:destroy-all` (see package.json).
+//
+// Compares real wall-clock time, against a real file-backed SQLite database (better-sqlite3,
+// the same engine `yarn test` already exercises via sqlite-node), between:
+//   - "old": what every `Query#markAllAsDeleted()`/`destroyAllPermanently()` did before this PR
+//     -- one `database.batch()` call (one adapter transaction) per matching record
+//   - "new": what it does now -- one `adapter.destroyMatching()` call total, regardless of how
+//     many records match (see Database#_performMassDestroy / each DatabaseAdapter#destroyMatching)
+//
+// Sample output (M-series MacBook, your numbers will vary with disk/CPU):
+//   | records | old (ms)   | new (ms)   | speedup  |
+//   | ------ | ---------- | ---------- | -------- |
+//   |     50 |     13.1ms |      0.5ms |    27.5x |
+//   |    200 |     40.6ms |      0.5ms |    76.3x |
+//   |   1000 |    212.3ms |      1.7ms |   128.7x |
+//   |   5000 |   1611.7ms |     11.3ms |   142.6x |
+
+import Model from '../../../Model'
+import Database from '../../../Database'
+import { appSchema, tableSchema } from '../../../Schema'
+import { field } from '../../../decorators'
+import { toPromise } from '../../../utils/fp/Result'
+import SQLiteAdapter from '../../sqlite/index'
+import { fileDbName, cleanupDb } from './helpers'
+
+const schema = appSchema({
+  version: 1,
+  tables: [
+    tableSchema({
+      name: 'items',
+      columns: [{ name: 'position', type: 'number' }],
+    }),
+  ],
+})
+
+class Item extends Model {
+  static table = 'items'
+
+  @field('position')
+  position
+}
+
+async function makeDatabase() {
+  if (!require('fs').existsSync('.tmp')) {
+    require('fs').mkdirSync('.tmp')
+  }
+  const dbName = fileDbName('node')
+  const adapter = new SQLiteAdapter({ dbName, schema })
+  await adapter.initializingPromise
+  const database = new Database({ adapter, modelClasses: [Item] })
+  return { database, adapter, items: database.get(Item), dbName }
+}
+
+async function closeAndCleanup({ adapter, dbName }) {
+  await toPromise((callback) => adapter.unsafeCloseConnection(callback))
+  cleanupDb(dbName, 'node')
+}
+
+async function seed(items, count) {
+  await items.database.write(async () => {
+    const batch = []
+    for (let i = 0; i < count; i += 1) {
+      batch.push(items.prepareCreate((item) => (item.position = i)))
+    }
+    await items.database.batch(batch)
+  })
+}
+
+// Faithful to the pre-PR implementation: fetch full Model instances, then destroy each one via
+// its own database.batch() call -- one adapter transaction per record.
+async function oldDestroyAllPermanently(items) {
+  const records = await items.query().fetch()
+  await items.database.write(async () => {
+    for (const record of records) {
+      // eslint-disable-next-line no-await-in-loop
+      await items.database.batch(record.prepareDestroyPermanently())
+    }
+  })
+}
+
+async function newDestroyAllPermanently(items) {
+  await items.database.write(() => items.query().destroyAllPermanently())
+}
+
+async function timeMs(action) {
+  const started = performance.now()
+  await action()
+  return performance.now() - started
+}
+
+async function runOne(count) {
+  const oldDb = await makeDatabase()
+  await seed(oldDb.items, count)
+  const oldMs = await timeMs(() => oldDestroyAllPermanently(oldDb.items))
+  await closeAndCleanup(oldDb)
+
+  const newDb = await makeDatabase()
+  await seed(newDb.items, count)
+  const newMs = await timeMs(() => newDestroyAllPermanently(newDb.items))
+  await closeAndCleanup(newDb)
+
+  return { count, oldMs, newMs }
+}
+
+describe('destroyAllPermanently benchmark (old per-record batch loop vs new destroyMatching)', () => {
+  it('reports real wall-clock timing at increasing scale', async () => {
+    const sampleSizes = [50, 200, 1000, 5000]
+    const results = []
+    for (const count of sampleSizes) {
+      // eslint-disable-next-line no-await-in-loop
+      results.push(await runOne(count))
+    }
+
+    const fmt = (ms) => `${ms.toFixed(1)}ms`
+    const rows = results.map(
+      ({ count, oldMs, newMs }) =>
+        `| ${String(count).padStart(6)} | ${fmt(oldMs).padStart(10)} | ${fmt(newMs).padStart(10)} | ${`${(oldMs / newMs).toFixed(1)}x`.padStart(8)} |`,
+    )
+    console.log(`
+destroyAllPermanently: old (N transactions) vs new (destroyMatching, 1 op) -- real-sqlite-node timing
+| records | old (ms)   | new (ms)   | speedup  |
+| ------ | ---------- | ---------- | -------- |
+${rows.join('\n')}
+`)
+
+    // Sanity, not the point of this file: the new implementation should never be slower.
+    results.forEach(({ oldMs, newMs }) => {
+      expect(newMs).toBeLessThan(oldMs)
+    })
+  }, 120000)
+})

--- a/src/adapters/compat.ts
+++ b/src/adapters/compat.ts
@@ -59,6 +59,12 @@ export default class DatabaseAdapterCompat {
     return toPromise((callback) => this.underlyingAdapter.batch(operations, callback))
   }
 
+  destroyMatching(query: SerializedQuery, permanently: boolean): Promise<RecordId[]> {
+    return toPromise((callback) =>
+      this.underlyingAdapter.destroyMatching(query, permanently, callback),
+    )
+  }
+
   getDeletedRecords(tableName: TableName): Promise<RecordId[]> {
     return toPromise((callback) => this.underlyingAdapter.getDeletedRecords(tableName, callback))
   }

--- a/src/adapters/lokijs/common.ts
+++ b/src/adapters/lokijs/common.ts
@@ -10,6 +10,7 @@ export type WorkerExecutorType =
   | 'unsafeQueryRaw'
   | 'count'
   | 'batch'
+  | 'destroyMatching'
   | 'getDeletedRecords'
   | 'unsafeResetDatabase'
   | 'unsafeExecute'

--- a/src/adapters/lokijs/index.ts
+++ b/src/adapters/lokijs/index.ts
@@ -114,6 +114,15 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     this._dispatcher.call('batch', [operations], callback, 'shallowCloneDeepObjects')
   }
 
+  destroyMatching(
+    query: SerializedQuery,
+    permanently: boolean,
+    callback: ResultCallback<RecordId[]>,
+  ): void {
+    validateTable(query.table, this.schema)
+    this._dispatcher.call('destroyMatching', [query, permanently], callback)
+  }
+
   getDeletedRecords(table: TableName, callback: ResultCallback<RecordId[]>): void {
     validateTable(table, this.schema)
     this._dispatcher.call('getDeletedRecords', [table], callback)

--- a/src/adapters/lokijs/type.ts
+++ b/src/adapters/lokijs/type.ts
@@ -27,6 +27,7 @@ export type LokiCollection = {
   remove: (doc: LokiRawDocument) => unknown
   find: (query: LokiQueryObject) => LokiRawDocument[]
   findAndUpdate: (query: LokiQueryObject, updateFn: (doc: LokiRawDocument) => void) => unknown
+  findAndRemove: (query: LokiQueryObject) => unknown
   ensureIndex: (field: string) => void
   data: LokiRawDocument[]
 }

--- a/src/adapters/lokijs/worker/DatabaseDriver.ts
+++ b/src/adapters/lokijs/worker/DatabaseDriver.ts
@@ -215,6 +215,33 @@ export default class DatabaseDriver {
     }
   }
 
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). Reuses executeQuery() -- the exact
+  // same join/sort/take/skip-aware resolution queryIds() already uses -- to find which ids
+  // match, then applies the delete/soft-delete to precisely that id set via one bulk Loki call
+  // (findAndRemove/findAndUpdate) instead of looping per record the way batch() above must for
+  // an explicit list of individually-prepared operations.
+  destroyMatching(query: SerializedQuery, permanently: boolean): RecordId[] {
+    this._assertNotBroken()
+
+    const { table } = query
+    const ids = executeQuery(query, this.loki).map((record) => record.id as RecordId)
+
+    if (ids.length) {
+      const collection = this.loki.getCollection(table)
+      const idFilter = { id: { $in: ids } }
+      if (permanently) {
+        collection.findAndRemove(idFilter)
+      } else {
+        collection.findAndUpdate(idFilter, (doc) => {
+          doc._status = 'deleted'
+        })
+      }
+    }
+
+    ids.forEach((id) => this.removeFromCache(table, id))
+    return ids
+  }
+
   getDeletedRecords(table: TableName): RecordId[] {
     return this.loki
       .getCollection(table)

--- a/src/adapters/remote/index.ts
+++ b/src/adapters/remote/index.ts
@@ -52,6 +52,14 @@ export default class RemoteAdapter implements DatabaseAdapter {
     this.handler('batch', [operations], callback)
   }
 
+  destroyMatching(
+    query: SerializedQuery,
+    permanently: boolean,
+    callback: ResultCallback<RecordId[]>,
+  ): void {
+    this.handler('destroyMatching', [query, permanently], callback)
+  }
+
   getDeletedRecords(tableName: TableName, callback: ResultCallback<RecordId[]>): void {
     this.handler('getDeletedRecords', [tableName], callback)
   }

--- a/src/adapters/sqlite/encodeDestroyMatchingMutation/index.ts
+++ b/src/adapters/sqlite/encodeDestroyMatchingMutation/index.ts
@@ -1,0 +1,25 @@
+import type { TableName } from '../../../Schema'
+import type { SQL } from '../type'
+
+// Shared by the sqlite-node and sqlite-wasm DatabaseDriver#destroyMatching() implementations
+// (the native/shared C++ path mirrors the same logic in its own language, see
+// native/shared/Database-batch.cpp's Database::destroyMatching).
+//
+// `sql` is the exact same query that would otherwise power queryIds() for this table. When
+// there's a predicate at all, it's reused as an inline derived table (`where "id" in (select
+// "id" from (<sql>))`), so no `WHERE id IN (?,?,...)` argument list ever needs to be built. When
+// there's no predicate (isUnconditional), skips straight to a bare delete/update instead, so
+// SQLite can take its own optimized path for an unconditional DELETE.
+export default function encodeDestroyMatchingMutation(
+  table: TableName,
+  sql: SQL,
+  permanently: boolean,
+  isUnconditional: boolean,
+): SQL {
+  if (isUnconditional) {
+    return permanently ? `delete from "${table}"` : `update "${table}" set "_status" = 'deleted'`
+  }
+  return permanently
+    ? `delete from "${table}" where "id" in (select "id" from (${sql}))`
+    : `update "${table}" set "_status" = 'deleted' where "id" in (select "id" from (${sql}))`
+}

--- a/src/adapters/sqlite/encodeDestroyMatchingMutation/test.js
+++ b/src/adapters/sqlite/encodeDestroyMatchingMutation/test.js
@@ -1,0 +1,21 @@
+import encodeDestroyMatchingMutation from './index'
+
+describe('encodeDestroyMatchingMutation', () => {
+  const sql = 'select "tasks".* from "tasks" where "tasks"."name" is ?'
+
+  it('wraps the query as a derived table when there is a predicate', () => {
+    expect(encodeDestroyMatchingMutation('tasks', sql, true, false)).toBe(
+      `delete from "tasks" where "id" in (select "id" from (${sql}))`,
+    )
+    expect(encodeDestroyMatchingMutation('tasks', sql, false, false)).toBe(
+      `update "tasks" set "_status" = 'deleted' where "id" in (select "id" from (${sql}))`,
+    )
+  })
+
+  it('skips straight to a bare statement when unconditional', () => {
+    expect(encodeDestroyMatchingMutation('tasks', sql, true, true)).toBe('delete from "tasks"')
+    expect(encodeDestroyMatchingMutation('tasks', sql, false, true)).toBe(
+      `update "tasks" set "_status" = 'deleted'`,
+    )
+  })
+})

--- a/src/adapters/sqlite/index.ts
+++ b/src/adapters/sqlite/index.ts
@@ -285,6 +285,29 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     )
   }
 
+  destroyMatching(
+    query: SerializedQuery,
+    permanently: boolean,
+    callback: ResultCallback<RecordId[]>,
+  ): void {
+    validateTable(query.table, this.schema)
+    const { table, description, associations } = query
+    // "The whole table" -- no predicate at all -- gets a bare delete/update below instead of a
+    // `where id in (...)` filter, so SQLite can take its truncate-optimization fast path (see
+    // native/shared/Database-batch.cpp's Database::destroyMatching for the full reasoning).
+    const isUnconditional =
+      !description.sql &&
+      !description.where.length &&
+      !associations.length &&
+      !description.take &&
+      !description.skip
+    this._dispatcher.call(
+      'destroyMatching',
+      [table, ...encodeQuery(query), permanently, isUnconditional],
+      callback,
+    )
+  }
+
   getDeletedRecords(table: TableName, callback: ResultCallback<RecordId[]>): void {
     validateTable(table, this.schema)
     this._dispatcher.call(

--- a/src/adapters/sqlite/sqlite-node/DatabaseBridge.ts
+++ b/src/adapters/sqlite/sqlite-node/DatabaseBridge.ts
@@ -204,6 +204,21 @@ class DatabaseBridge {
     this.withDriver(tag, resolve, reject, 'batch', (driver) => driver.batch(operations))
   }
 
+  destroyMatching(
+    tag: number,
+    table: string,
+    sql: string,
+    args: SQLiteArg[],
+    permanently: boolean,
+    isUnconditional: boolean,
+    resolve: (value: unknown) => void,
+    reject: (code: string, message: string, error: Error) => void,
+  ): void {
+    this.withDriver(tag, resolve, reject, 'destroyMatching', (driver) =>
+      driver.destroyMatching(table, sql, args, permanently, isUnconditional),
+    )
+  }
+
   unsafeResetDatabase(
     tag: number,
     schema: string,

--- a/src/adapters/sqlite/sqlite-node/DatabaseDriver.ts
+++ b/src/adapters/sqlite/sqlite-node/DatabaseDriver.ts
@@ -176,6 +176,43 @@ class DatabaseDriver {
     })
   }
 
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). `sql`/`args` are exactly what would
+  // otherwise be passed to queryIds() for this same Query. Reused here twice: once as-is to
+  // collect which ids match, and (unless `isUnconditional`) a second time wrapped as an inline
+  // derived table inside the actual DELETE/UPDATE, so no `WHERE id IN (?,?,…)` argument list
+  // needs to be built here, and no separate id-based batch call needs to happen at all.
+  destroyMatching(
+    table: string,
+    sql: string,
+    args: SQLiteArg[],
+    permanently: boolean,
+    isUnconditional: boolean,
+  ): string[] {
+    const fixedArgs = fixArgs(args)
+    let ids: string[] = []
+
+    this.database.inTransaction(() => {
+      ids = this.database.queryRaw(sql, fixedArgs).map((row) => `${row.id}`)
+      if (ids.length === 0) {
+        return
+      }
+
+      if (isUnconditional) {
+        this.database.execute(
+          permanently ? `DELETE FROM '${table}'` : `UPDATE '${table}' SET _status = 'deleted'`,
+        )
+      } else {
+        const mutationSql = permanently
+          ? `DELETE FROM '${table}' WHERE id IN (SELECT id FROM (${sql}))`
+          : `UPDATE '${table}' SET _status = 'deleted' WHERE id IN (SELECT id FROM (${sql}))`
+        this.database.execute(mutationSql, fixedArgs)
+      }
+    })
+
+    ids.forEach((id) => this.removeFromCache(table, id))
+    return ids
+  }
+
   // MARK: - LocalStorage
 
   getLocal(key: string): unknown {

--- a/src/adapters/sqlite/sqlite-node/DatabaseDriver.ts
+++ b/src/adapters/sqlite/sqlite-node/DatabaseDriver.ts
@@ -1,5 +1,6 @@
 import Database from './Database'
 import type { NativeBridgeBatchOperation, SQLiteArg } from '../type'
+import encodeDestroyMatchingMutation from '../encodeDestroyMatchingMutation'
 
 function fixArgs(args: SQLiteArg[]): SQLiteArg[] {
   return args.map((value) => {
@@ -176,11 +177,8 @@ class DatabaseDriver {
     })
   }
 
-  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). `sql`/`args` are exactly what would
-  // otherwise be passed to queryIds() for this same Query. Reused here twice: once as-is to
-  // collect which ids match, and (unless `isUnconditional`) a second time wrapped as an inline
-  // derived table inside the actual DELETE/UPDATE, so no `WHERE id IN (?,?,…)` argument list
-  // needs to be built here, and no separate id-based batch call needs to happen at all.
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently() -- see encodeDestroyMatchingMutation
+  // for what the resulting statement looks like and why.
   destroyMatching(
     table: string,
     sql: string,
@@ -197,16 +195,8 @@ class DatabaseDriver {
         return
       }
 
-      if (isUnconditional) {
-        this.database.execute(
-          permanently ? `DELETE FROM '${table}'` : `UPDATE '${table}' SET _status = 'deleted'`,
-        )
-      } else {
-        const mutationSql = permanently
-          ? `DELETE FROM '${table}' WHERE id IN (SELECT id FROM (${sql}))`
-          : `UPDATE '${table}' SET _status = 'deleted' WHERE id IN (SELECT id FROM (${sql}))`
-        this.database.execute(mutationSql, fixedArgs)
-      }
+      const mutationSql = encodeDestroyMatchingMutation(table, sql, permanently, isUnconditional)
+      this.database.execute(mutationSql, isUnconditional ? [] : fixedArgs)
     })
 
     ids.forEach((id) => this.removeFromCache(table, id))

--- a/src/adapters/sqlite/sqlite-node/__tests__/destroyMatching.test.js
+++ b/src/adapters/sqlite/sqlite-node/__tests__/destroyMatching.test.js
@@ -1,0 +1,106 @@
+import DatabaseDriver from '../DatabaseDriver'
+import Database from '../Database'
+
+// Exercises DatabaseDriver#destroyMatching() against a real better-sqlite3 engine (not a mock),
+// since its whole point is reusing the passed-in `sql` as an inline derived table inside the
+// actual DELETE/UPDATE statement (`where "id" in (select "id" from (<sql>))`) -- this is the one
+// backend where that SQL can be validated against a real SQLite implementation in CI.
+
+function makeDriver() {
+  const driver = new DatabaseDriver()
+  driver.database = new Database(':memory:')
+  driver.database.executeStatements(
+    'create table "tasks" ("id" text primary key, "_status" text, "_changed" text, "name" text);',
+  )
+  return driver
+}
+
+function insertTask(driver, id, name) {
+  driver.database.execute(
+    'insert into "tasks" ("id", "_status", "_changed", "name") values (?, ?, ?, ?)',
+    [id, 'synced', '', name],
+  )
+}
+
+function allTasks(driver) {
+  return driver.database.queryRaw('select * from "tasks"')
+}
+
+describe('NodeJS DatabaseDriver#destroyMatching', () => {
+  it('permanently destroys only matching records, reusing the query as a subquery', () => {
+    const driver = makeDriver()
+    insertTask(driver, 't1', 'foo')
+    insertTask(driver, 't2', 'foo')
+    insertTask(driver, 't3', 'bar')
+
+    const sql = 'select "tasks".* from "tasks" where "tasks"."name" is ?'
+    const ids = driver.destroyMatching('tasks', sql, ['foo'], true, false)
+
+    expect(ids.slice().sort()).toEqual(['t1', 't2'])
+    expect(allTasks(driver).map((row) => row.id)).toEqual(['t3'])
+  })
+
+  it('marks only matching records as deleted, reusing the query as a subquery', () => {
+    const driver = makeDriver()
+    insertTask(driver, 't1', 'foo')
+    insertTask(driver, 't2', 'bar')
+
+    const sql = 'select "tasks".* from "tasks" where "tasks"."name" is ?'
+    const ids = driver.destroyMatching('tasks', sql, ['foo'], false, false)
+
+    expect(ids).toEqual(['t1'])
+    const rows = allTasks(driver)
+    expect(rows.find((row) => row.id === 't1')._status).toBe('deleted')
+    expect(rows.find((row) => row.id === 't2')._status).toBe('synced')
+  })
+
+  it('destroys everything via a bare statement when isUnconditional is true', () => {
+    const driver = makeDriver()
+    insertTask(driver, 't1', 'foo')
+    insertTask(driver, 't2', 'bar')
+
+    const ids = driver.destroyMatching('tasks', 'select "tasks".* from "tasks"', [], true, true)
+
+    expect(ids.slice().sort()).toEqual(['t1', 't2'])
+    expect(allTasks(driver)).toEqual([])
+  })
+
+  it('marks everything as deleted via a bare statement when isUnconditional is true', () => {
+    const driver = makeDriver()
+    insertTask(driver, 't1', 'foo')
+    insertTask(driver, 't2', 'bar')
+
+    const ids = driver.destroyMatching('tasks', 'select "tasks".* from "tasks"', [], false, true)
+
+    expect(ids.slice().sort()).toEqual(['t1', 't2'])
+    expect(allTasks(driver).every((row) => row._status === 'deleted')).toBe(true)
+  })
+
+  it('returns an empty array and changes nothing when nothing matches', () => {
+    const driver = makeDriver()
+    insertTask(driver, 't1', 'foo')
+
+    const sql = 'select "tasks".* from "tasks" where "tasks"."name" is ?'
+    const ids = driver.destroyMatching('tasks', sql, ['nope'], true, false)
+
+    expect(ids).toEqual([])
+    expect(allTasks(driver)).toHaveLength(1)
+  })
+
+  it('removes destroyed ids from the "already sent to JS" cache', () => {
+    const driver = makeDriver()
+    insertTask(driver, 't1', 'foo')
+    driver.markAsCached('tasks', 't1')
+    expect(driver.isCached('tasks', 't1')).toBe(true)
+
+    driver.destroyMatching(
+      'tasks',
+      'select "tasks".* from "tasks" where "tasks"."id" is ?',
+      ['t1'],
+      true,
+      false,
+    )
+
+    expect(driver.isCached('tasks', 't1')).toBe(false)
+  })
+})

--- a/src/adapters/sqlite/sqlite-wasm/DatabaseDriver.ts
+++ b/src/adapters/sqlite/sqlite-wasm/DatabaseDriver.ts
@@ -209,6 +209,42 @@ export default class DatabaseDriver {
     removed.forEach(([table, id]) => this.removeFromCache(table, id))
   }
 
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). `sql`/`args` are exactly what would
+  // otherwise be passed to queryIds() for this same Query. Reused here twice: once as-is to
+  // collect which ids match, and (unless `isUnconditional`) a second time wrapped as an inline
+  // derived table inside the actual DELETE/UPDATE, so no `WHERE id IN (?,?,…)` argument list
+  // needs to be built here, and no separate id-based batch call needs to happen at all.
+  async destroyMatching(
+    table: string,
+    sql: string,
+    args: SQLiteArg[],
+    permanently: boolean,
+    isUnconditional: boolean,
+  ): Promise<string[]> {
+    let ids: string[] = []
+
+    await this.inTransaction(async () => {
+      ids = (await this.queryRaw(sql, args)).map((row) => String(row.id))
+      if (ids.length === 0) {
+        return
+      }
+
+      if (isUnconditional) {
+        await this.execute(
+          permanently ? `DELETE FROM "${table}"` : `UPDATE "${table}" SET "_status" = 'deleted'`,
+        )
+      } else {
+        const mutationSql = permanently
+          ? `DELETE FROM "${table}" WHERE "id" IN (SELECT "id" FROM (${sql}))`
+          : `UPDATE "${table}" SET "_status" = 'deleted' WHERE "id" IN (SELECT "id" FROM (${sql}))`
+        await this.execute(mutationSql, args)
+      }
+    })
+
+    ids.forEach((id) => this.removeFromCache(table, id))
+    return ids
+  }
+
   async getLocal(key: string): Promise<unknown> {
     const rows = await this.queryRaw('SELECT "value" FROM "local_storage" WHERE "key" = ?', [key])
     return rows.length ? rows[0].value : null

--- a/src/adapters/sqlite/sqlite-wasm/DatabaseDriver.ts
+++ b/src/adapters/sqlite/sqlite-wasm/DatabaseDriver.ts
@@ -1,4 +1,5 @@
 import type { NativeBridgeBatchOperation, SQLiteArg } from '../type'
+import encodeDestroyMatchingMutation from '../encodeDestroyMatchingMutation'
 
 type SQLiteValue = string | number | bigint | Uint8Array | null
 
@@ -209,11 +210,8 @@ export default class DatabaseDriver {
     removed.forEach(([table, id]) => this.removeFromCache(table, id))
   }
 
-  // Powers Query#markAllAsDeleted()/destroyAllPermanently(). `sql`/`args` are exactly what would
-  // otherwise be passed to queryIds() for this same Query. Reused here twice: once as-is to
-  // collect which ids match, and (unless `isUnconditional`) a second time wrapped as an inline
-  // derived table inside the actual DELETE/UPDATE, so no `WHERE id IN (?,?,…)` argument list
-  // needs to be built here, and no separate id-based batch call needs to happen at all.
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently() -- see encodeDestroyMatchingMutation
+  // for what the resulting statement looks like and why.
   async destroyMatching(
     table: string,
     sql: string,
@@ -229,16 +227,8 @@ export default class DatabaseDriver {
         return
       }
 
-      if (isUnconditional) {
-        await this.execute(
-          permanently ? `DELETE FROM "${table}"` : `UPDATE "${table}" SET "_status" = 'deleted'`,
-        )
-      } else {
-        const mutationSql = permanently
-          ? `DELETE FROM "${table}" WHERE "id" IN (SELECT "id" FROM (${sql}))`
-          : `UPDATE "${table}" SET "_status" = 'deleted' WHERE "id" IN (SELECT "id" FROM (${sql}))`
-        await this.execute(mutationSql, args)
-      }
+      const mutationSql = encodeDestroyMatchingMutation(table, sql, permanently, isUnconditional)
+      await this.execute(mutationSql, isUnconditional ? [] : args)
     })
 
     ids.forEach((id) => this.removeFromCache(table, id))

--- a/src/adapters/sqlite/sqlite-wasm/workerRuntime.ts
+++ b/src/adapters/sqlite/sqlite-wasm/workerRuntime.ts
@@ -277,6 +277,17 @@ async function dispatch(request: WorkerRequest): Promise<unknown> {
       invalidateAfterMutation(runtime, tag, connectionKey, true)
       return result
     }
+    case 'destroyMatching': {
+      const result = await driver.destroyMatching(
+        String(args[0]),
+        String(args[1]),
+        args[2] as SQLiteArg[],
+        Boolean(args[3]),
+        Boolean(args[4]),
+      )
+      invalidateAfterMutation(runtime, tag, connectionKey, true)
+      return result
+    }
     case 'unsafeLoadFromSync': {
       const jsonId = Number(args[0])
       const providedJsons = syncJsons.get(tag)

--- a/src/adapters/sqlite/type.ts
+++ b/src/adapters/sqlite/type.ts
@@ -83,6 +83,7 @@ export type SqliteDispatcherMethod =
   | 'unsafeQueryRaw'
   | 'count'
   | 'batch'
+  | 'destroyMatching'
   | 'unsafeLoadFromSync'
   | 'provideSyncJson'
   | 'unsafeResetDatabase'

--- a/src/adapters/type.ts
+++ b/src/adapters/type.ts
@@ -47,6 +47,17 @@ export interface DatabaseAdapter {
   // Executes multiple prepared operations
   batch(operations: BatchOperation[], callback: ResultCallback<void>): void
 
+  // Permanently destroys (or marks as deleted) every record matching `query`, in a single
+  // operation -- without ever fetching full rows or instantiating them. Returns the ids that
+  // were actually affected, already evicted from this adapter's own "already sent to JS" record
+  // cache (if it has one). Powers Query#markAllAsDeleted()/destroyAllPermanently(); see there and
+  // Database#_performMassDestroy for why this exists instead of resolving ids and batching by id.
+  destroyMatching(
+    query: SerializedQuery,
+    permanently: boolean,
+    callback: ResultCallback<RecordId[]>,
+  ): void
+
   // Return marked as deleted records
   getDeletedRecords(tableName: TableName, callback: ResultCallback<RecordId[]>): void
 

--- a/src/nitro/Nitromelon.nitro.ts
+++ b/src/nitro/Nitromelon.nitro.ts
@@ -23,6 +23,13 @@ export interface NitromelonDatabase extends HybridObject<{ ios: 'c++'; android: 
   unsafeQueryRaw(sql: string, args: SqliteValue[]): AnyMap[]
   count(sql: string, args: SqliteValue[]): number
   batch(operations: NitromelonBatchOperation[]): void
+  // Powers Query#markAllAsDeleted()/destroyAllPermanently(): `sql`/`args` are the exact same
+  // query that would otherwise be used for `queryIds()`. Collects the matching ids, then --
+  // unless `isUnconditional` (no where/join/take/skip at all, i.e. "the whole table"), in which
+  // case it skips straight to an unconditional delete/update to unlock SQLite's own truncate
+  // optimization -- deletes/marks-deleted those exact rows by reusing `sql`/`args` again as an
+  // inline subquery, all in one transaction. Returns the ids that were actually affected.
+  destroyMatching(table: string, sql: string, args: SqliteValue[], permanently: boolean, isUnconditional: boolean): string[]
   batchJSON(operations: string): void
   getLocal(key: string): NitromelonLocalValue
   unsafeLoadFromSync(jsonId: number, schema: AnyMap, preamble: string, postamble: string): AnyMap


### PR DESCRIPTION
## Summary

Makes `Query#markAllAsDeleted()`/`destroyAllPermanently()` fast, and gives them a real, safe alternative to raw SQL for clearing or pruning a table. Includes e2e coverage and two independent real benchmarks (Node/better-sqlite3, and on-device).

1. **Single transaction.** These methods used to call `markAsDeleted()`/`destroyPermanently()` on each matching record individually — one `database.batch()` call, i.e. one SQLite transaction, *per row*. Now every matching record is committed via a single `database.batch()` call, one transaction regardless of match count.
2. **Skip full-row fetch for uncached records.** Still building a full `Model` for every matching row (a `select *`, cache insert, etc.) just to immediately destroy it was pure overhead for rows nobody had loaded. Now a `Model` is only built for ids already resident in the `RecordCache` (i.e. something might be observing it — required for correctness, not just perf, since `processChangeSet.ts` diffs live subscriptions by object identity). Uncached ids skip straight to a raw op.
3. **One native operation, no per-id batch at all.** Even resolving ids via a separate query and then sending them back as a batch of individual `DELETE ... WHERE id = ?` executions meant a full row scan, a second bridge crossing, N statement executions, and no chance for the engine's own bulk-delete optimizations (e.g. SQLite's page-truncation fast path for an unconditional `DELETE`) to kick in. Now `DatabaseAdapter#destroyMatching(query, permanently)` resolves AND mutates in one call, implemented per backend:
   - **SQLite** (native/shared C++, shared by iOS/Android/Windows via Nitro): reuses the exact SQL that would otherwise power `queryIds()` — once to collect matching ids, and again wrapped as an inline derived table inside the actual `DELETE`/`UPDATE` (`where id in (select id from (<sql>))`), so no `WHERE id IN (?,?,...)` list ever needs to be built or chunked. An unconditional query (no `Q.where`/joins/take/skip at all) skips straight to a bare `delete from table`, unlocking SQLite's truncate optimization.
   - **sqlite-node** and **sqlite-wasm**: the same subquery-reuse approach, sharing one small `encodeDestroyMatchingMutation()` helper between the two drivers.
   - **LokiJS**: reuses the existing join/sort/take/skip-aware query resolution to find matching ids, then applies the change via one bulk `findAndRemove`/`findAndUpdate` call instead of looping per record.
4. **Docs + a cleanup pass.** Documented the new recommended pattern (see below), de-duplicated the mutation-SQL-building logic that had been copied near-verbatim between the sqlite-node and sqlite-wasm drivers (which also fixed a leftover quote-style inconsistency between them), and trimmed comment duplication that had built up across earlier commits.
5. **E2e coverage for the native path.** Added a Maestro flow (`examples/NotesApp/maestro/delete-all.yaml`) and a "Delete all" button in the NotesApp example, wired to `notes.query().destroyAllPermanently()` — the unconditional "clear the whole table" path specifically. **Run for real**: built the app for iOS Simulator from this branch (native/shared C++ `Database::destroyMatching` compiled cleanly, 0 errors) and ran the full `maestro test maestro/` suite — 7/7 flows passed in 2m38s, no regressions from the new button.
6. **A real, reproducible Node benchmark.** `yarn benchmark:destroy-all` times the pre-PR approach (N individual `database.batch()` calls) against the current one, against a real file-backed SQLite database (better-sqlite3):
   ```
   | records | old (ms)   | new (ms)   | speedup  |
   |     50 |     11.3ms |      0.5ms |    20.6x |
   |    200 |     39.9ms |      0.6ms |    70.0x |
   |   1000 |    212.5ms |      1.7ms |   128.4x |
   |   5000 |   1275.1ms |      8.9ms |   143.6x |
   ```
7. **The same comparison on-device, plus a real upstream reference point.** The repo already has an `examples/benchmark` app pair (NitromelonDB vs upstream WatermelonDB, real-device stress test). Added a "Mass delete: old vs new" card to the NitromelonDB app, and a matching "Mass delete (reference)" card to the WatermelonDB app that just times its own `destroyAllPermanently()` at the same sizes (upstream has no `destroyMatching()` to compare internally). **Built, ran, and manually verified both apps on iOS Simulator**:
   ```
   NitromelonDB: old vs new
   | records | old (ms) | new (ms) | speedup |
   |   1,000 |    36.1  |    2.4   |  14.9x  |
   |   5,000 |   194.3  |   14.0   |  13.9x  |
   |  20,000 |   761.4  |   68.7   |  11.1x  |

   WatermelonDB (upstream): plain removal, for reference
   | records | time (ms) |
   |   1,000 |     41.6  |
   |   5,000 |    185.6  |
   |  20,000 |    680.2  |
   ```
   Upstream's numbers track NitromelonDB's own "old" column closely (same algorithm, as expected) — and NitromelonDB's `destroyMatching()` path is ~10-17x faster than actual upstream WatermelonDB at these sizes, not just faster than its own prior implementation.
8. **Backwards-compatible for custom adapters.** `destroyMatching()` is a new method on `DatabaseAdapter`, implemented by all three built-in adapters (SQLite/LokiJS/Remote) here. A fully custom third-party adapter that hasn't added it yet doesn't break: `Database#_performMassDestroy` detects a missing `destroyMatching` at runtime and transparently falls back to the old resolve-ids-then-batch approach (still avoiding a per-record transaction and a full-row fetch for uncached ids — just without the single native-operation path), logging one console warning telling the adapter's maintainer what to implement.

Usage is unchanged and, since this is exposed as a `Query` method, "clear a whole table" and "clear a table except some rows" both just fall out of the existing `Q.where`/`Q.notEq`/`Q.notIn` clause API:
```js
// clear the whole table
await database.write(() => tasks.query().destroyAllPermanently())

// clear everything except a few ids
await database.write(() =>
  tasks.query(Q.where('id', Q.notIn(idsToKeep))).destroyAllPermanently()
)
```

## Docs
- `docs-website/docs/docs/CRUD.md`: new "Delete all records matching a query" section, cross-linked from the existing "wipe every table on logout" and "unsafe raw execute" advice — pointing people at this instead of raw SQL.
- `docs-website/docs/docs/Query.md`: short pointer to the same section.
- `CHANGELOG-Unreleased.md`: performance entry, including how to reproduce the Node benchmark.
- `examples/NotesApp/README.md`: new flow listed in the Maestro table.
- `examples/benchmark/README.md`: new section on the on-device mass-delete cards (both apps).

## Test plan
- [x] `yarn jest` — full library suite, 967 passed
- [x] New `destroyMatching` coverage in the shared adapter conformance suite (`commonTests.js`), run for real against **both** the SQLite (better-sqlite3) and LokiJS backends
- [x] New `sqlite-node/__tests__/destroyMatching.test.js` validating the derived-table-subquery SQL directly against a real SQLite engine
- [x] New 10k-row `destroyMatching` cases (predicate + unconditional) in the large-batch suite, against a real file-backed SQLite database (~72ms each)
- [x] New unit test for the shared `encodeDestroyMatchingMutation()` helper
- [x] New `sqlite-wasm/DatabaseDriver.test.js` coverage for `destroyMatching()` (the predicate branch, the unconditional bare-mutation branch, `permanently: false`, and the empty-match early return) — closes the one backend that previously had no direct test for this feature
- [x] New `Database/test.js` coverage for the compatibility fallback: correct raw batch operations + record counts for both `markAllAsDeleted()`/`destroyAllPermanently()` when `destroyMatching` is missing, and that the "missing method" warning fires once, not on every call
- [x] New `yarn benchmark:destroy-all` script with real old-vs-new timing (Node/better-sqlite3, see above)
- [x] `yarn tsc --noEmit`, `yarn eslint` — clean
- [x] **Native iOS build + full Maestro suite, run for real** — `7/7 Flows Passed in 2m 38s`, including `delete-all.yaml`
- [x] **On-device mass-delete benchmark cards, built + run + manually verified for real** — see numbers above

The native/shared C++ path (iOS/Android/Windows) has now been built and exercised for real twice (NotesApp e2e, benchmark app), closing the one gap called out in earlier revisions of this PR.

<img width="378" height="407" alt="image" src="https://github.com/user-attachments/assets/6249cacd-48a9-4e00-a78f-23518236e253" />

<img width="386" height="419" alt="image" src="https://github.com/user-attachments/assets/f1631970-753a-4e5b-a538-3ccd9dea7ebd" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


